### PR TITLE
feat: have deploy task depend on writeBuildInfo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ deployArtifact.jarTask = jar
 wpi.java.configureExecutableTasks(jar)
 wpi.java.configureTestTasks(test)
 
-deploy.dependsOn 'writeBuildInfo'
+deployroborio.dependsOn 'writeBuildInfo'
 build.dependsOn 'writeBuildInfo'
 
 task writeBuildInfo {

--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ deployArtifact.jarTask = jar
 wpi.java.configureExecutableTasks(jar)
 wpi.java.configureTestTasks(test)
 
-
+deploy.dependsOn 'writeBuildInfo'
 build.dependsOn 'writeBuildInfo'
 
 task writeBuildInfo {


### PR DESCRIPTION
This PR adds the `writeBuildInfo` task to the `deploy` task. This hasn't been tested yet so please don't merge yet.

Signed-off-by: Matt Gleich <git@mattglei.ch>