### PR TITLE
Implement Preferences from Network Tables

### DIFF
--- a/config_dash/proto/shuffleboard.json
+++ b/config_dash/proto/shuffleboard.json
@@ -1037,6 +1037,39 @@
               "_source0": "network_table:///SmartDashboard/Drive.defCommand",
               "_title": "Drive.defCommand"
             }
+          },
+          "29,0": {
+            "size": [
+              4,
+              8
+            ],
+            "content": {
+              "_type": "List Layout",
+              "_title": "Preferences",
+              "Layout/Label position": "TOP",
+              "_children": [
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Drive.P",
+                  "_title": "Drive.P"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Drive.I",
+                  "_title": "Drive.I"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Drive.D",
+                  "_title": "Drive.D"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Drive.F",
+                  "_title": "Drive.F"
+                }
+              ]
+            }
           }
         }
       }
@@ -1359,6 +1392,44 @@
               "_source0": "network_table:///SmartDashboard/Shooter.speed",
               "_title": "Shooter.speed"
             }
+          },
+          "29,0": {
+            "size": [
+              4,
+              10
+            ],
+            "content": {
+              "_type": "List Layout",
+              "_title": "Preferences",
+              "Layout/Label position": "TOP",
+              "_children": [
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Shooter.P",
+                  "_title": "Shooter.P"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Shooter.I",
+                  "_title": "Shooter.I"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Shooter.D",
+                  "_title": "Shooter.D"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Shooter.F",
+                  "_title": "Shooter.F"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Shooter.scale",
+                  "_title": "Shooter.scale"
+                }
+              ]
+            }
           }
         }
       }
@@ -1396,7 +1467,7 @@
               "_title": "Turret.implClass"
             }
           },
-          "25,0": {
+          "22,0": {
             "size": [
               5,
               2
@@ -1409,7 +1480,7 @@
               "Colors/Color when false": "#8B0000FF"
             }
           },
-          "20,0": {
+          "17,0": {
             "size": [
               5,
               2
@@ -1420,7 +1491,7 @@
               "_title": "TurretLocation.implClass"
             }
           },
-          "20,2": {
+          "17,2": {
             "size": [
               5,
               2
@@ -1462,6 +1533,39 @@
               "_type": "Text View",
               "_source0": "network_table:///SmartDashboard/Turret.speed",
               "_title": "Turret.speed"
+            }
+          },
+          "29,0": {
+            "size": [
+              4,
+              8
+            ],
+            "content": {
+              "_type": "List Layout",
+              "_title": "Preferences",
+              "Layout/Label position": "TOP",
+              "_children": [
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Turret.P",
+                  "_title": "Turret.P"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Turret.I",
+                  "_title": "Turret.I"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Turret.D",
+                  "_title": "Turret.D"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Turret.F",
+                  "_title": "Turret.F"
+                }
+              ]
             }
           }
         }
@@ -2956,9 +3060,9 @@
     }
   ],
   "windowGeometry": {
-    "x": -5.599999904632568,
+    "x": -6.0,
     "y": 4.0,
-    "width": 1553.5999755859375,
-    "height": 666.4000244140625
+    "width": 1554.0,
+    "height": 667.0
   }
 }

--- a/config_dash/real/shuffleboard.json
+++ b/config_dash/real/shuffleboard.json
@@ -1037,6 +1037,39 @@
               "_source0": "network_table:///SmartDashboard/Drive.defCommand",
               "_title": "Drive.defCommand"
             }
+          },
+          "29,0": {
+            "size": [
+              4,
+              8
+            ],
+            "content": {
+              "_type": "List Layout",
+              "_title": "Preferences",
+              "Layout/Label position": "TOP",
+              "_children": [
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Drive.P",
+                  "_title": "Drive.P"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Drive.I",
+                  "_title": "Drive.I"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Drive.D",
+                  "_title": "Drive.D"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Drive.F",
+                  "_title": "Drive.F"
+                }
+              ]
+            }
           }
         }
       }
@@ -1359,6 +1392,44 @@
               "_source0": "network_table:///SmartDashboard/Shooter.speed",
               "_title": "Shooter.speed"
             }
+          },
+          "29,0": {
+            "size": [
+              4,
+              10
+            ],
+            "content": {
+              "_type": "List Layout",
+              "_title": "Preferences",
+              "Layout/Label position": "TOP",
+              "_children": [
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Shooter.P",
+                  "_title": "Shooter.P"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Shooter.I",
+                  "_title": "Shooter.I"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Shooter.D",
+                  "_title": "Shooter.D"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Shooter.F",
+                  "_title": "Shooter.F"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Shooter.scale",
+                  "_title": "Shooter.scale"
+                }
+              ]
+            }
           }
         }
       }
@@ -1396,7 +1467,7 @@
               "_title": "Turret.implClass"
             }
           },
-          "25,0": {
+          "22,0": {
             "size": [
               5,
               2
@@ -1409,7 +1480,7 @@
               "Colors/Color when false": "#8B0000FF"
             }
           },
-          "20,0": {
+          "17,0": {
             "size": [
               5,
               2
@@ -1420,7 +1491,7 @@
               "_title": "TurretLocation.implClass"
             }
           },
-          "20,2": {
+          "17,2": {
             "size": [
               5,
               2
@@ -1462,6 +1533,39 @@
               "_type": "Text View",
               "_source0": "network_table:///SmartDashboard/Turret.speed",
               "_title": "Turret.speed"
+            }
+          },
+          "29,0": {
+            "size": [
+              4,
+              8
+            ],
+            "content": {
+              "_type": "List Layout",
+              "_title": "Preferences",
+              "Layout/Label position": "TOP",
+              "_children": [
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Turret.P",
+                  "_title": "Turret.P"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Turret.I",
+                  "_title": "Turret.I"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Turret.D",
+                  "_title": "Turret.D"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Turret.F",
+                  "_title": "Turret.F"
+                }
+              ]
             }
           }
         }
@@ -2956,9 +3060,9 @@
     }
   ],
   "windowGeometry": {
-    "x": -5.599999904632568,
+    "x": -6.0,
     "y": 4.0,
-    "width": 1553.5999755859375,
-    "height": 666.4000244140625
+    "width": 1554.0,
+    "height": 667.0
   }
 }

--- a/config_dash/suitcase/shuffleboard.json
+++ b/config_dash/suitcase/shuffleboard.json
@@ -1037,6 +1037,39 @@
               "_source0": "network_table:///SmartDashboard/Drive.defCommand",
               "_title": "Drive.defCommand"
             }
+          },
+          "29,0": {
+            "size": [
+              4,
+              8
+            ],
+            "content": {
+              "_type": "List Layout",
+              "_title": "Preferences",
+              "Layout/Label position": "TOP",
+              "_children": [
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Drive.P",
+                  "_title": "Drive.P"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Drive.I",
+                  "_title": "Drive.I"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Drive.D",
+                  "_title": "Drive.D"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Drive.F",
+                  "_title": "Drive.F"
+                }
+              ]
+            }
           }
         }
       }
@@ -1359,6 +1392,44 @@
               "_source0": "network_table:///SmartDashboard/Shooter.speed",
               "_title": "Shooter.speed"
             }
+          },
+          "29,0": {
+            "size": [
+              4,
+              10
+            ],
+            "content": {
+              "_type": "List Layout",
+              "_title": "Preferences",
+              "Layout/Label position": "TOP",
+              "_children": [
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Shooter.P",
+                  "_title": "Shooter.P"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Shooter.I",
+                  "_title": "Shooter.I"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Shooter.D",
+                  "_title": "Shooter.D"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Shooter.F",
+                  "_title": "Shooter.F"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Shooter.scale",
+                  "_title": "Shooter.scale"
+                }
+              ]
+            }
           }
         }
       }
@@ -1396,7 +1467,7 @@
               "_title": "Turret.implClass"
             }
           },
-          "25,0": {
+          "22,0": {
             "size": [
               5,
               2
@@ -1409,7 +1480,7 @@
               "Colors/Color when false": "#8B0000FF"
             }
           },
-          "20,0": {
+          "17,0": {
             "size": [
               5,
               2
@@ -1420,7 +1491,7 @@
               "_title": "TurretLocation.implClass"
             }
           },
-          "20,2": {
+          "17,2": {
             "size": [
               5,
               2
@@ -1462,6 +1533,39 @@
               "_type": "Text View",
               "_source0": "network_table:///SmartDashboard/Turret.speed",
               "_title": "Turret.speed"
+            }
+          },
+          "29,0": {
+            "size": [
+              4,
+              8
+            ],
+            "content": {
+              "_type": "List Layout",
+              "_title": "Preferences",
+              "Layout/Label position": "TOP",
+              "_children": [
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Turret.P",
+                  "_title": "Turret.P"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Turret.I",
+                  "_title": "Turret.I"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Turret.D",
+                  "_title": "Turret.D"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Turret.F",
+                  "_title": "Turret.F"
+                }
+              ]
             }
           }
         }
@@ -2956,9 +3060,9 @@
     }
   ],
   "windowGeometry": {
-    "x": -5.599999904632568,
+    "x": -6.0,
     "y": 4.0,
-    "width": 1553.5999755859375,
-    "height": 666.4000244140625
+    "width": 1554.0,
+    "height": 667.0
   }
 }

--- a/config_dash/zester/shuffleboard.json
+++ b/config_dash/zester/shuffleboard.json
@@ -1037,6 +1037,39 @@
               "_source0": "network_table:///SmartDashboard/Drive.defCommand",
               "_title": "Drive.defCommand"
             }
+          },
+          "29,0": {
+            "size": [
+              4,
+              8
+            ],
+            "content": {
+              "_type": "List Layout",
+              "_title": "Preferences",
+              "Layout/Label position": "TOP",
+              "_children": [
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Drive.P",
+                  "_title": "Drive.P"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Drive.I",
+                  "_title": "Drive.I"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Drive.D",
+                  "_title": "Drive.D"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Drive.F",
+                  "_title": "Drive.F"
+                }
+              ]
+            }
           }
         }
       }
@@ -1359,6 +1392,44 @@
               "_source0": "network_table:///SmartDashboard/Shooter.speed",
               "_title": "Shooter.speed"
             }
+          },
+          "29,0": {
+            "size": [
+              4,
+              10
+            ],
+            "content": {
+              "_type": "List Layout",
+              "_title": "Preferences",
+              "Layout/Label position": "TOP",
+              "_children": [
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Shooter.P",
+                  "_title": "Shooter.P"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Shooter.I",
+                  "_title": "Shooter.I"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Shooter.D",
+                  "_title": "Shooter.D"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Shooter.F",
+                  "_title": "Shooter.F"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Shooter.scale",
+                  "_title": "Shooter.scale"
+                }
+              ]
+            }
           }
         }
       }
@@ -1396,7 +1467,7 @@
               "_title": "Turret.implClass"
             }
           },
-          "25,0": {
+          "22,0": {
             "size": [
               5,
               2
@@ -1409,7 +1480,7 @@
               "Colors/Color when false": "#8B0000FF"
             }
           },
-          "20,0": {
+          "17,0": {
             "size": [
               5,
               2
@@ -1420,7 +1491,7 @@
               "_title": "TurretLocation.implClass"
             }
           },
-          "20,2": {
+          "17,2": {
             "size": [
               5,
               2
@@ -1462,6 +1533,39 @@
               "_type": "Text View",
               "_source0": "network_table:///SmartDashboard/Turret.speed",
               "_title": "Turret.speed"
+            }
+          },
+          "29,0": {
+            "size": [
+              4,
+              8
+            ],
+            "content": {
+              "_type": "List Layout",
+              "_title": "Preferences",
+              "Layout/Label position": "TOP",
+              "_children": [
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Turret.P",
+                  "_title": "Turret.P"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Turret.I",
+                  "_title": "Turret.I"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Turret.D",
+                  "_title": "Turret.D"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///Preferences/Turret.F",
+                  "_title": "Turret.F"
+                }
+              ]
             }
           }
         }
@@ -2956,9 +3060,9 @@
     }
   ],
   "windowGeometry": {
-    "x": -5.599999904632568,
+    "x": -6.0,
     "y": 4.0,
-    "width": 1553.5999755859375,
-    "height": 666.4000244140625
+    "width": 1554.0,
+    "height": 667.0
   }
 }

--- a/config_robot/proto/networktables.ini
+++ b/config_robot/proto/networktables.ini
@@ -1,7 +1,15 @@
 [NetworkTables Storage 3.0]
 string "/Preferences/.type"="RobotPreferences"
+double "/Preferences/Drive.P"=0
+double "/Preferences/Drive.I"=0
 double "/Preferences/Drive.D"=0
 double "/Preferences/Drive.F"=0
-double "/Preferences/Drive.I"=0
-double "/Preferences/Drive.P"=0
-
+double "/Preferences/Turret.P"=0
+double "/Preferences/Turret.I"=0
+double "/Preferences/Turret.D"=0
+double "/Preferences/Turret.F"=0
+double "/Preferences/Shooter.P"=0
+double "/Preferences/Shooter.I"=0
+double "/Preferences/Shooter.D"=0
+double "/Preferences/Shooter.F"=0
+double "/Preferences/Shooter.scale"=1

--- a/config_robot/real/networktables.ini
+++ b/config_robot/real/networktables.ini
@@ -1,7 +1,15 @@
 [NetworkTables Storage 3.0]
 string "/Preferences/.type"="RobotPreferences"
+double "/Preferences/Drive.P"=0
+double "/Preferences/Drive.I"=0
 double "/Preferences/Drive.D"=0
 double "/Preferences/Drive.F"=0
-double "/Preferences/Drive.I"=0
-double "/Preferences/Drive.P"=0
-
+double "/Preferences/Turret.P"=0
+double "/Preferences/Turret.I"=0
+double "/Preferences/Turret.D"=0
+double "/Preferences/Turret.F"=0
+double "/Preferences/Shooter.P"=0
+double "/Preferences/Shooter.I"=0
+double "/Preferences/Shooter.D"=0
+double "/Preferences/Shooter.F"=0
+double "/Preferences/Shooter.scale"=1

--- a/config_robot/suitcase/networktables.ini
+++ b/config_robot/suitcase/networktables.ini
@@ -1,3 +1,15 @@
 [NetworkTables Storage 3.0]
 string "/Preferences/.type"="RobotPreferences"
-string "/Preferences/Test_Pref"=0
+double "/Preferences/Drive.P"=0
+double "/Preferences/Drive.I"=0
+double "/Preferences/Drive.D"=0
+double "/Preferences/Drive.F"=0
+double "/Preferences/Turret.P"=0
+double "/Preferences/Turret.I"=0
+double "/Preferences/Turret.D"=0
+double "/Preferences/Turret.F"=0
+double "/Preferences/Shooter.P"=0
+double "/Preferences/Shooter.I"=0
+double "/Preferences/Shooter.D"=0
+double "/Preferences/Shooter.F"=0
+double "/Preferences/Shooter.scale"=1

--- a/config_robot/zester/networktables.ini
+++ b/config_robot/zester/networktables.ini
@@ -1,3 +1,15 @@
 [NetworkTables Storage 3.0]
 string "/Preferences/.type"="RobotPreferences"
-string "/Preferences/Test_Pref"=0
+double "/Preferences/Drive.P"=0
+double "/Preferences/Drive.I"=0
+double "/Preferences/Drive.D"=0
+double "/Preferences/Drive.F"=0
+double "/Preferences/Turret.P"=0
+double "/Preferences/Turret.I"=0
+double "/Preferences/Turret.D"=0
+double "/Preferences/Turret.F"=0
+double "/Preferences/Shooter.P"=0
+double "/Preferences/Shooter.I"=0
+double "/Preferences/Shooter.D"=0
+double "/Preferences/Shooter.F"=0
+double "/Preferences/Shooter.scale"=1

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -12,6 +12,7 @@
 
 package frc.robot;
 
+
 import java.util.List;
 
 import edu.wpi.first.wpilibj.DriverStation;
@@ -21,6 +22,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.WaitCommand;
+
 import frc.robot.commands.DoNothing;
 import frc.robot.commands.PKParallelCommandGroup;
 import frc.robot.commands.PKSequentialCommandGroup;
@@ -47,6 +49,7 @@ import frc.robot.subsystems.SubsystemFactory;
 
 import riolog.PKLogger;
 import riolog.RioLogger;
+
 
 /**
  * The VM is configured to automatically run this class, and to call the
@@ -142,7 +145,6 @@ public class Robot extends TimedRobot {
      * data, which holds the run-spinTime configuration.
      **/
     private void waitForDriverStationData() {
-
         long count = 0;
         while (!DriverStation.isNewControlData()) {
             if ((count % 100) == 0) {

--- a/src/main/java/frc/robot/config/BuildVersionInfo.java
+++ b/src/main/java/frc/robot/config/BuildVersionInfo.java
@@ -19,6 +19,6 @@ package frc.robot.config;
  **/
 class BuildVersionInfo {
     public static final String programmer = "Stu Lewin";
-    public static final String commitSHA = "a6d7569";
-    public static final String timeStamp = "20220224-061707";
+    public static final String commitSHA = "b91ce3d";
+    public static final String timeStamp = "20220226-125133";
 }

--- a/src/main/java/frc/robot/preferences/PreferenceNames.java
+++ b/src/main/java/frc/robot/preferences/PreferenceNames.java
@@ -8,39 +8,12 @@
 
 package frc.robot.preferences;
 
-import frc.robot.subsystems.SubsystemNames;
 
 /**
  * Add your docs here.
  */
 public class PreferenceNames {
 
-    public final class Drive {
-        public static final String name = SubsystemNames.driveName;
-        public static final String pid_P = name + ".P";
-        public static final String pid_I = name + ".I";
-        public static final String pid_D = name + ".D";
-        public static final String pid_F = name + ".F";
-    }
-
-    public final class Turret {
-        public static final String name = SubsystemNames.turretName;
-        // PID for turret position
-        public static final String pid_P = name + ".P";
-        public static final String pid_I = name + ".I";
-        public static final String pid_D = name + ".D";
-        public static final String pid_F = name + ".F";
-    }
-
-    public final class Shooter {
-        public static final String name = SubsystemNames.shooterName;
-        // PID for shooter speed
-        public static final String pid_P = name + ".P";
-        public static final String pid_I = name + ".I";
-        public static final String pid_D = name + ".D";
-        public static final String pid_F = name + ".F";
-        // Scale applied to shooter speed when in manual
-        public static final String scale = name + ".scale";
-    }
+    // There are no 'global' level preferences to define here
 
 }

--- a/src/main/java/frc/robot/subsystems/drive/BaseDriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/drive/BaseDriveSubsystem.java
@@ -9,6 +9,7 @@
 package frc.robot.subsystems.drive;
 
 
+import edu.wpi.first.wpilibj.Preferences;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
@@ -34,6 +35,18 @@ abstract class BaseDriveSubsystem extends SubsystemBase implements IDriveSubsyst
 
     /** Our subsystem's name **/
     protected static final String myName = SubsystemNames.driveName;
+
+    /** Default preferences for subystem **/
+    private final double default_pid_P = 0.0;
+    private final double default_pid_I = 0.0;
+    private final double default_pid_D = 0.0;
+    private final double default_pid_F = 0.0;
+
+    /** PID for subystem **/
+    protected double pid_P = 0;
+    protected double pid_I = 0;
+    protected double pid_D = 0;
+    protected double pid_F = 0;
 
     BaseDriveSubsystem() {
         logger.info("constructing");
@@ -65,6 +78,24 @@ abstract class BaseDriveSubsystem extends SubsystemBase implements IDriveSubsyst
 
         setDefaultCommand(ourCommand);
         SmartDashboard.putString(TelemetryNames.Drive.defCommand, ourCommand.getClass().getSimpleName());
+    }
+    
+    protected void loadPreferences() {
+        double v;
+
+        logger.info("new preferences for {}:", myName);
+        v = Preferences.getDouble(DrivePreferences.pid_P, default_pid_P);
+        logger.info("{} = {}", DrivePreferences.pid_P, v);
+        pid_P = v;
+        v = Preferences.getDouble(DrivePreferences.pid_I, default_pid_I);
+        logger.info("{} = {}", DrivePreferences.pid_I, v);
+        pid_I = v;
+        v = Preferences.getDouble(DrivePreferences.pid_D, default_pid_D);
+        logger.info("{} = {}", DrivePreferences.pid_D, v);
+        pid_D = v;
+        v = Preferences.getDouble(DrivePreferences.pid_F, default_pid_F);
+        logger.info("{} = {}", DrivePreferences.pid_F, v);
+        pid_F = v;
     }
 
     protected double speed = 0.0;

--- a/src/main/java/frc/robot/subsystems/drive/BaseDriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/drive/BaseDriveSubsystem.java
@@ -109,5 +109,10 @@ abstract class BaseDriveSubsystem extends SubsystemBase implements IDriveSubsyst
         SmartDashboard.putNumber(TelemetryNames.Drive.leftSpeed, leftSpeed);
         SmartDashboard.putNumber(TelemetryNames.Drive.rightSpeed, rightSpeed);
     }
+    
+    @Override
+    public void updatePreferences() {
+        loadPreferences();
+    }
 
 }

--- a/src/main/java/frc/robot/subsystems/drive/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/drive/DriveSubsystem.java
@@ -146,12 +146,14 @@ class DriveSubsystem extends BaseDriveSubsystem {
 
     @Override
     public void validateCalibration() {
-        // TODO Auto-generated method stub
+        // Nothing here
     }
 
     @Override
     public void updatePreferences() {
-        // TODO Auto-generated method stub
+        super.loadPreferences();
+
+        // Nothing extra here
     }
 
     @Override

--- a/src/main/java/frc/robot/subsystems/drive/ProtoDriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/drive/ProtoDriveSubsystem.java
@@ -133,26 +133,25 @@ class ProtoDriveSubsystem extends BaseDriveSubsystem {
     @Override
     public void updateTelemetry() {
         super.updateTelemetry();
-        // TODO Auto-generated method stub
 
+        // Nothing extra here
     }
 
     @Override
     public void validateCalibration() {
-        // TODO Auto-generated method stub
-
+        // Nothing here
     }
 
     @Override
     public void updatePreferences() {
-        // TODO Auto-generated method stub
+        super.updateTelemetry();
 
+        // Nothing extra here
     }
 
     @Override
     public void disable() {
         // TODO Auto-generated method stub
-
     }
 
     @Override

--- a/src/main/java/frc/robot/subsystems/drive/StubDriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/drive/StubDriveSubsystem.java
@@ -47,6 +47,7 @@ class StubDriveSubsystem extends BaseDriveSubsystem {
 
     @Override
     public void updatePreferences() {
+        super.updateTelemetry();
         // Stub doesn't implement this
     }
 

--- a/src/main/java/frc/robot/subsystems/drive/SuitcaseDriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/drive/SuitcaseDriveSubsystem.java
@@ -67,26 +67,25 @@ class SuitcaseDriveSubsystem extends BaseDriveSubsystem {
     @Override
     public void updateTelemetry() {
         super.updateTelemetry();
-        // TODO Auto-generated method stub
 
-    }
+        // Nothing extra here
+   }
 
     @Override
     public void validateCalibration() {
-        // TODO Auto-generated method stub
-
+        // Nothing here
     }
 
     @Override
     public void updatePreferences() {
-        // TODO Auto-generated method stub
+        super.updateTelemetry();
 
+        // Nothing extra here
     }
 
     @Override
     public void disable() {
         // TODO Auto-generated method stub
-
     }
 
     @Override

--- a/src/main/java/frc/robot/subsystems/drive/ZesterDriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/drive/ZesterDriveSubsystem.java
@@ -147,12 +147,14 @@ class ZesterDriveSubsystem extends BaseDriveSubsystem {
 
     @Override
     public void validateCalibration() {
-        // TODO Auto-generated method stub
+        // Not implemented
     }
 
     @Override
     public void updatePreferences() {
-        // TODO Auto-generated method stub
+        super.updateTelemetry();
+
+        // Nothing extra here
     }
 
     @Override

--- a/src/main/java/frc/robot/subsystems/shooter/BaseShooterSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/shooter/BaseShooterSubsystem.java
@@ -9,6 +9,7 @@
 package frc.robot.subsystems.shooter;
 
 
+import edu.wpi.first.wpilibj.Preferences;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
@@ -34,6 +35,21 @@ abstract class BaseShooterSubsystem extends SubsystemBase implements IShooterSub
 
     /** Our subsystem's name **/
     protected static final String myName = SubsystemNames.shooterName;
+
+    /** Default preferences for subystem **/
+    private final double default_pid_P = 0.0;
+    private final double default_pid_I = 0.0;
+    private final double default_pid_D = 0.0;
+    private final double default_pid_F = 0.0;
+    private final double default_scale = 1.0;
+
+    /** PID for subystem **/
+    protected double pid_P = 0;
+    protected double pid_I = 0;
+    protected double pid_D = 0;
+    protected double pid_F = 0;
+    /** Scale applied to shooter speed when in manual */
+    protected double scale = 1;
 
     BaseShooterSubsystem() {
         logger.info("constructing");
@@ -67,6 +83,26 @@ abstract class BaseShooterSubsystem extends SubsystemBase implements IShooterSub
         SmartDashboard.putString(TelemetryNames.Shooter.defCommand, ourCommand.getClass().getSimpleName());
     }
     
+    protected void loadPreferences() {
+        double v;
+
+        logger.info("new preferences for {}:", myName);
+        v = Preferences.getDouble(ShooterPreferences.pid_P, default_pid_P);
+        logger.info("{} = {}", ShooterPreferences.pid_P, v);
+        pid_P = v;
+        v = Preferences.getDouble(ShooterPreferences.pid_I, default_pid_I);
+        logger.info("{} = {}", ShooterPreferences.pid_I, v);
+        pid_I = v;
+        v = Preferences.getDouble(ShooterPreferences.pid_D, default_pid_D);
+        logger.info("{} = {}", ShooterPreferences.pid_D, v);
+        pid_D = v;
+        v = Preferences.getDouble(ShooterPreferences.pid_F, default_pid_F);
+        logger.info("{} = {}", ShooterPreferences.pid_F, v);
+        pid_F = v;
+        v = Preferences.getDouble(ShooterPreferences.scale, default_scale);
+        scale = v;
+    }
+
     // Current speed of motor
     private double tlmSpeed = 0.0;
     // Setting for speed of motor (target or direct)

--- a/src/main/java/frc/robot/subsystems/shooter/BaseShooterSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/shooter/BaseShooterSubsystem.java
@@ -122,5 +122,10 @@ abstract class BaseShooterSubsystem extends SubsystemBase implements IShooterSub
         SmartDashboard.putNumber(TelemetryNames.Shooter.speed, tlmSpeed);
         SmartDashboard.putNumber(TelemetryNames.Shooter.setSpeed, tlmSetSpeed);
      }
+        
+    @Override
+    public void updatePreferences() {
+        loadPreferences();
+    }
 
 }

--- a/src/main/java/frc/robot/subsystems/shooter/ShooterPreferences.java
+++ b/src/main/java/frc/robot/subsystems/shooter/ShooterPreferences.java
@@ -39,6 +39,8 @@ public final class ShooterPreferences {
     static final String pid_I = name + ".I";
     static final String pid_D = name + ".D";
     static final String pid_F = name + ".F";
+    // Scale applied to shooter speed when in manual
+    static final String scale = name + ".scale";
 
     private ShooterPreferences() {}
 
@@ -62,6 +64,11 @@ public final class ShooterPreferences {
         if (!Preferences.containsKey(pid_F)) {
             logger.warn("{} doesn't exist; creating with default", pid_F);
             Preferences.setDouble(pid_F, 0.0);
+        }
+
+        if (!Preferences.containsKey(scale)) {
+            logger.warn("{} doesn't exist; creating with default", scale);
+            Preferences.setDouble(scale, 1.0);
         }
     }
 

--- a/src/main/java/frc/robot/subsystems/shooter/ShooterPreferences.java
+++ b/src/main/java/frc/robot/subsystems/shooter/ShooterPreferences.java
@@ -34,7 +34,7 @@ public final class ShooterPreferences {
     /** Our classes' logger **/
     private static final PKLogger logger = RioLogger.getLogger(ShooterPreferences.class.getName());
 
-    static private final String name = SubsystemNames.driveName;
+    static private final String name = SubsystemNames.shooterName;
     static final String pid_P = name + ".P";
     static final String pid_I = name + ".I";
     static final String pid_D = name + ".D";

--- a/src/main/java/frc/robot/subsystems/shooter/ShooterSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/shooter/ShooterSubsystem.java
@@ -96,16 +96,14 @@ class ShooterSubsystem extends BaseShooterSubsystem {
 
     @Override
     public void validateCalibration() {
-        // Zester doesn't implement this
+        // Nothing here
     }
 
     @Override
     public void updatePreferences() {
-        // FIXME: Why is this? Isn't this updateTelemetry()?
-        SmartDashboard.putBoolean(TelemetryNames.Shooter.isActive, isActive);
-        SmartDashboard.putNumber(TelemetryNames.Shooter.rpm, encoder.getVelocity());
-        SmartDashboard.putNumber(TelemetryNames.Shooter.targetRpm, targetRpm);
-        SmartDashboard.putBoolean(TelemetryNames.Shooter.atTarget, atTargetVelocity());
+        super.updateTelemetry();
+
+        // Nothing extra here.
     }
 
     @Override

--- a/src/main/java/frc/robot/subsystems/shooter/StubShooterSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/shooter/StubShooterSubsystem.java
@@ -27,22 +27,25 @@ class StubShooterSubsystem extends BaseShooterSubsystem {
     @Override
     public void updateTelemetry() {
         super.updateTelemetry();
-        // Stub doesn't implement this
+
+        // Nothing extra here
     }
 
     @Override
     public void validateCalibration() {
-        // Stub doesn't implement this
+        // Nothing here
     }
 
     @Override
     public void updatePreferences() {
-        // Stub doesn't implement this
+        super.updateTelemetry();
+
+        // Nothing extra here
     }
 
     @Override
     public void disable() {
-        // Stub doesn't implement this
+        // 
     }
 
     @Override

--- a/src/main/java/frc/robot/subsystems/shooter/ZesterShooterSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/shooter/ZesterShooterSubsystem.java
@@ -93,16 +93,14 @@ class ZesterShooterSubsystem extends BaseShooterSubsystem {
 
     @Override
     public void validateCalibration() {
-        // Zester doesn't implement this
+        // Nothing here
     }
 
     @Override
     public void updatePreferences() {
-        // FIXME: Why is this? Isn't this updateTelemetry()?
-        SmartDashboard.putBoolean(TelemetryNames.Shooter.isActive, isActive);
-        SmartDashboard.putNumber(TelemetryNames.Shooter.rpm, encoder.getVelocity());
-        SmartDashboard.putNumber(TelemetryNames.Shooter.targetRpm, targetRpm);
-        SmartDashboard.putBoolean(TelemetryNames.Shooter.atTarget, atTargetVelocity());
+        super.updateTelemetry();
+
+        // Nothing extra here
     }
     
     @Override

--- a/src/main/java/frc/robot/subsystems/turret/BaseTurretSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/turret/BaseTurretSubsystem.java
@@ -118,4 +118,9 @@ abstract class BaseTurretSubsystem extends SubsystemBase implements ITurretSubsy
         SmartDashboard.putNumber(TelemetryNames.Turret.setSpeed, tlmSetSpeed);
      }
 
+     @Override
+     public void updatePreferences() {
+        loadPreferences();
+     }
+
 }

--- a/src/main/java/frc/robot/subsystems/turret/BaseTurretSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/turret/BaseTurretSubsystem.java
@@ -8,19 +8,22 @@
 
 package frc.robot.subsystems.turret;
 
+
 import edu.wpi.first.wpilibj.Preferences;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+
 import frc.robot.commands.turret.TurretDoNothing;
-import frc.robot.preferences.PreferenceNames;
 import frc.robot.properties.PKProperties;
 import frc.robot.properties.PropertiesManager;
 import frc.robot.subsystems.SubsystemNames;
 import frc.robot.telemetry.TelemetryNames;
 import frc.robot.utils.PKStatus;
+
 import riolog.PKLogger;
 import riolog.RioLogger;
+
 
 /**
  * Add your docs here.
@@ -33,10 +36,16 @@ abstract class BaseTurretSubsystem extends SubsystemBase implements ITurretSubsy
     /** Our subsystem's name **/
     protected static final String myName = SubsystemNames.turretName;
 
-    /** Turret PID defaults for subystem **/
-    protected double pid_P = 0.5;
-    protected double pid_I = 0.005;
-    protected double pid_D = 1;
+    /** Default preferences for subystem **/
+    private final double default_pid_P = 0.5;
+    private final double default_pid_I = 0.005;
+    private final double default_pid_D = 1.0;
+    private final double default_pid_F = 0.0;
+
+    /** PID for subystem **/
+    protected double pid_P = 0;
+    protected double pid_I = 0;
+    protected double pid_D = 0;
     protected double pid_F = 0;
 
     BaseTurretSubsystem() {
@@ -75,17 +84,17 @@ abstract class BaseTurretSubsystem extends SubsystemBase implements ITurretSubsy
         double v;
 
         logger.info("new preferences for {}:", myName);
-        v = Preferences.getDouble(PreferenceNames.Turret.pid_P, 0.5);
-        logger.info("{} = {}", PreferenceNames.Turret.pid_P, v);
+        v = Preferences.getDouble(TurretPreferences.pid_P, default_pid_P);
+        logger.info("{} = {}", TurretPreferences.pid_P, v);
         pid_P = v;
-        v = Preferences.getDouble(PreferenceNames.Turret.pid_I, 0.005);
-        logger.info("{} = {}", PreferenceNames.Turret.pid_I, v);
+        v = Preferences.getDouble(TurretPreferences.pid_I, default_pid_I);
+        logger.info("{} = {}", TurretPreferences.pid_I, v);
         pid_I = v;
-        v = Preferences.getDouble(PreferenceNames.Turret.pid_D, 1);
-        logger.info("{} = {}", PreferenceNames.Turret.pid_D, v);
+        v = Preferences.getDouble(TurretPreferences.pid_D, default_pid_D);
+        logger.info("{} = {}", TurretPreferences.pid_D, v);
         pid_D = v;
-        v = Preferences.getDouble(PreferenceNames.Turret.pid_F, 0.0);
-        logger.info("{} = {}", PreferenceNames.Turret.pid_F, v);
+        v = Preferences.getDouble(TurretPreferences.pid_F, default_pid_F);
+        logger.info("{} = {}", TurretPreferences.pid_F, v);
         pid_F = v;
     }
 

--- a/src/main/java/frc/robot/subsystems/turret/StubTurretSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/turret/StubTurretSubsystem.java
@@ -27,22 +27,25 @@ class StubTurretSubsystem extends BaseTurretSubsystem {
     @Override
     public void updateTelemetry() {
         super.updateTelemetry();
-        // Stub doesn't implement this
+
+        // Nothing extra here
     }
 
     @Override
     public void validateCalibration() {
-        // Stub doesn't implement this
+        // Nothing here
     }
 
     @Override
     public void updatePreferences() {
-        // Stub doesn't implement this
+        super.updateTelemetry();
+
+        // Nothing extra here
     }
 
     @Override
     public void disable() {
-        // Stub doesn't implement this
+        // Nothing here
     }
     
     @Override

--- a/src/main/java/frc/robot/subsystems/turret/TurretPreferences.java
+++ b/src/main/java/frc/robot/subsystems/turret/TurretPreferences.java
@@ -34,7 +34,7 @@ public final class TurretPreferences {
     /** Our classes' logger **/
     private static final PKLogger logger = RioLogger.getLogger(TurretPreferences.class.getName());
 
-    static private final String name = SubsystemNames.driveName;
+    static private final String name = SubsystemNames.turretName;
     static final String pid_P = name + ".P";
     static final String pid_I = name + ".I";
     static final String pid_D = name + ".D";

--- a/src/main/java/frc/robot/subsystems/turret/TurretSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/turret/TurretSubsystem.java
@@ -92,12 +92,12 @@ class TurretSubsystem extends BaseTurretSubsystem {
 
     @Override
     public void validateCalibration() {
-        // Zester doens't implement this
+        // Nothing here
     }
 
     @Override
     public void updatePreferences() {
-        loadPreferences();
+        super.updatePreferences();
 
         if (pid != null) {
             pid.setP(pid_P, 1);

--- a/src/main/java/frc/robot/subsystems/turret/ZesterTurretSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/turret/ZesterTurretSubsystem.java
@@ -8,6 +8,7 @@
 
 package frc.robot.subsystems.turret;
 
+
 import com.revrobotics.CANSparkMax;
 import com.revrobotics.RelativeEncoder;
 import com.revrobotics.SparkMaxPIDController;
@@ -16,13 +17,16 @@ import com.revrobotics.CANSparkMaxLowLevel.MotorType;
 
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+
 import frc.robot.sensors.turretlocation.ITurretLocationSensor;
 import frc.robot.sensors.turretlocation.TurretLocationFactory;
 import frc.robot.sensors.vision.IVisionSensor;
 import frc.robot.sensors.vision.VisionFactory;
 import frc.robot.telemetry.TelemetryNames;
+
 import riolog.PKLogger;
 import riolog.RioLogger;
+
 
 class ZesterTurretSubsystem extends BaseTurretSubsystem {
 
@@ -89,12 +93,12 @@ class ZesterTurretSubsystem extends BaseTurretSubsystem {
 
     @Override
     public void validateCalibration() {
-        // Zester doens't implement this
+        // Nothing here
     }
 
     @Override
     public void updatePreferences() {
-        loadPreferences();
+        super.updatePreferences();
 
         if (pid != null) {
             pid.setP(pid_P, 1);
@@ -102,7 +106,6 @@ class ZesterTurretSubsystem extends BaseTurretSubsystem {
             pid.setD(pid_D, 1);
             pid.setFF(pid_F, 1);
         }
-
     }
 
     @Override


### PR DESCRIPTION
Add implementation of the Preferences (from network tables). Includes some refactoring similar to Properties in terms of how constants for names are defined.  Also updates to dashboard to give edit capability with start of either auto or teleop modes. And initial versions of the network tables file get controlled.

Resolves #22.