### PR TITLE
Refactor Default Commands to Base Class

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -23,7 +23,7 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.WaitCommand;
 
-import frc.robot.commands.DoNothing;
+import frc.robot.commands.AutoDoNothing;
 import frc.robot.commands.FirePoseVision;
 import frc.robot.commands.PKParallelCommandGroup;
 import frc.robot.commands.PKSequentialCommandGroup;
@@ -198,7 +198,7 @@ public class Robot extends TimedRobot {
     private void createAutoChooser() {
         autoChooser = new SendableChooser<>();
 
-        autoChooser.setDefaultOption("Do Nothing", new DoNothing());
+        autoChooser.setDefaultOption("Do Nothing", new AutoDoNothing());
 
         // FIXME: This only works because default shooter command is idle
 

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -363,7 +363,7 @@ public class Robot extends TimedRobot {
         }
         for (ISubsystem s : subsystems) {
             s.updatePreferences();
-            s.loadDefaultAutoCommand();
+            s.setDefaultAutoCommand();
         }
 
         // CommandScheduler.getInstance().schedule(true, new DriveForwardTimed());
@@ -437,7 +437,7 @@ public class Robot extends TimedRobot {
         }
         for (ISubsystem s : subsystems) {
             s.updatePreferences();
-            s.loadDefaultTeleCommand();
+            s.setDefaultTeleCommand();
         }
 
         logger.info("initialized teleop");

--- a/src/main/java/frc/robot/commands/AutoDoNothing.java
+++ b/src/main/java/frc/robot/commands/AutoDoNothing.java
@@ -1,0 +1,30 @@
+/*-----------------------------------------------------------------------*/
+/* Copyright (c) Team 501 - The PowerKnights. All Rights Reserved.       */
+/* Open Source Software - may be modified and shared by other FRC teams  */
+/* under the terms of the Team501 license. The code must be accompanied  */
+/* by the Team 501 - The PowerKnights license file in the root directory */
+/* of this project.                                                      */
+/*-----------------------------------------------------------------------*/
+
+package frc.robot.commands;
+
+
+import riolog.PKLogger;
+import riolog.RioLogger;
+
+
+/**
+ * Provides an implementation of the DoNothing command for Auto mode.
+ * <p>
+ * Mostly so the logging and telemetry displays are more exact.
+ */
+public class AutoDoNothing extends DoNothing {
+    
+    /** Our classes' logger **/
+    private static final PKLogger logger = RioLogger.getLogger(AutoDoNothing.class.getName());
+
+    public AutoDoNothing() {
+        logger.info("constructing {}", getName());
+    }
+
+}

--- a/src/main/java/frc/robot/config/BuildVersionInfo.java
+++ b/src/main/java/frc/robot/config/BuildVersionInfo.java
@@ -19,6 +19,6 @@ package frc.robot.config;
  **/
 class BuildVersionInfo {
     public static final String programmer = "Stu Lewin";
-    public static final String commitSHA = "54e44a0";
-    public static final String timeStamp = "20220305-102926";
+    public static final String commitSHA = "650a5ac";
+    public static final String timeStamp = "20220311-051229";
 }

--- a/src/main/java/frc/robot/properties/PropertiesManager.java
+++ b/src/main/java/frc/robot/properties/PropertiesManager.java
@@ -24,7 +24,6 @@ import static java.util.Map.Entry.*;
 
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
-import frc.robot.properties.PropertyNames.Robot;
 import frc.robot.telemetry.TelemetryNames;
 import frc.robot.utils.PKStatus;
 
@@ -70,9 +69,9 @@ public class PropertiesManager {
 
         // Put robot info into dashboard (tests successful access)
         PKProperties props = ourInstance.getProperties(PropertyNames.Robot.name);
-        robotName = props.getString(Robot.robotName);
+        robotName = props.getString(PropertyNames.Robot.robotName);
         SmartDashboard.putString(TelemetryNames.Misc.robotName, robotName);
-        robotImpl = props.getString(Robot.implementation);
+        robotImpl = props.getString(PropertyNames.Robot.implementation);
         SmartDashboard.putString(TelemetryNames.Misc.robotImpl, robotImpl);
 
         // Check to see if file exists and mark as failed if not

--- a/src/main/java/frc/robot/subsystems/BaseSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/BaseSubsystem.java
@@ -47,13 +47,13 @@ public abstract class BaseSubsystem implements ISubsystem {
 
     @Override
     public void setDefaultAutoCommand() {
-        logger.info("{} set default auto to {}", myName, defaultAutoCommand.getName());
+        logger.info("{} set default auto command to {}", myName, defaultAutoCommand.getName());
         setDefaultCommand(defaultAutoCommand);
     }
 
     @Override
     public void setDefaultTeleCommand() {
-        logger.info("{} set default teleop to {}", myName, defaultTeleCommand.getName());
+        logger.info("{} set default teleop command to {}", myName, defaultTeleCommand.getName());
         setDefaultCommand(defaultTeleCommand);
     }
     

--- a/src/main/java/frc/robot/subsystems/BaseSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/BaseSubsystem.java
@@ -1,0 +1,124 @@
+/*-----------------------------------------------------------------------*/
+/* Copyright (c) Team 501 - The PowerKnights. All Rights Reserved.       */
+/* Open Source Software - may be modified and shared by other FRC teams  */
+/* under the terms of the Team501 license. The code must be accompanied  */
+/* by the Team 501 - The PowerKnights license file in the root directory */
+/* of this project.                                                      */
+/*-----------------------------------------------------------------------*/
+
+package frc.robot.subsystems;
+
+
+import java.lang.reflect.InvocationTargetException;
+
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import edu.wpi.first.wpilibj2.command.Command;
+
+import frc.robot.commands.DoNothing;
+import frc.robot.commands.PKCommandBase;
+import frc.robot.properties.PKProperties;
+import frc.robot.properties.PropertiesManager;
+import frc.robot.telemetry.TelemetryNames;
+import frc.robot.utils.PKStatus;
+
+import riolog.PKLogger;
+import riolog.RioLogger;
+
+
+public abstract class BaseSubsystem implements ISubsystem {
+    
+    /** Our classes' logger **/
+    private static final PKLogger logger = RioLogger.getLogger(BaseSubsystem.class.getName());
+
+    /** Our subsystem's name **/
+    protected final String myName;
+
+    /** Objects to hold loaded default commands **/
+    protected static Command defaultAutoCommand;
+    protected static Command defaultTeleCommand;
+
+    public BaseSubsystem(String name) {
+        logger.info("constructing");
+
+        myName = name;
+
+        logger.info("constructed");
+    }
+
+    /**
+     * Called to load the default commands for the subsystem (both
+     * autonomous and teleop); the values are determined from the
+     * properties file and loaded dynamically.
+     * 
+     * @param doNothingClass - class to default to if not found or errors
+     **/
+    protected void loadDefaultCommands(Class<PKCommandBase> doNothingClass) {
+        logger.debug("loading for {}", myName);
+
+        PKProperties props = PropertiesManager.getInstance().getProperties(myName);
+        String myAutoClassName = props.getString("autoCommandName");
+        if (myAutoClassName.isEmpty()) {
+            logger.info("no class specified; go with subsystem default (do nothing)");
+            myAutoClassName = new StringBuilder().append(myName).append("DoNothing").toString();
+        }
+        String myPkgName = doNothingClass.getPackage().getName();
+        String classToLoad = new StringBuilder().append(myPkgName).append(".").append(myAutoClassName).toString();
+        logger.debug("class to load: {}", classToLoad);
+
+        logger.info("constructing {} for {} subsystem", myAutoClassName, myName);
+        Command ourAutoCommand;
+        try {
+            @SuppressWarnings("rawtypes")
+            Class myClass = Class.forName(classToLoad);
+            @SuppressWarnings("deprecation")
+            Object myObject = myClass.newInstance();
+            ourAutoCommand = (Command) myObject;
+        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException ex) {
+            logger.error("failed to load class; instantiating default stub for: {}", myName);
+            try {
+                ourAutoCommand = (Command) doNothingClass.getDeclaredConstructor().newInstance();
+            } catch (InstantiationException | IllegalAccessException | IllegalArgumentException
+                    | InvocationTargetException | NoSuchMethodException | SecurityException e) {
+                logger.error("failed to load do nothing class; instantiating stub for: {}", myName);
+                ourAutoCommand = new DoNothing();
+            }
+            SmartDashboard.putNumber(TelemetryNames.Climber.status, PKStatus.degraded.tlmValue);
+        }
+
+        defaultAutoCommand = ourAutoCommand;
+        SmartDashboard.putString(TelemetryNames.Climber.autoCommand, ourAutoCommand.getClass().getSimpleName());
+
+        String myTeleClassName = props.getString("teleCommandName");
+        if (myTeleClassName.isEmpty()) {
+            logger.info("no class specified; go with subsystem default (do nothing)");
+            myTeleClassName = new StringBuilder().append(myName).append("DoNothing").toString();
+        }
+        myPkgName = doNothingClass.getPackage().getName();
+        classToLoad = new StringBuilder().append(myPkgName).append(".").append(myTeleClassName).toString();
+        logger.debug("class to load: {}", classToLoad);
+
+        logger.info("constructing {} for {} subsystem", myTeleClassName, myName);
+        Command ourTeleCommand;
+        try {
+            @SuppressWarnings("rawtypes")
+            Class myClass = Class.forName(classToLoad);
+            @SuppressWarnings("deprecation")
+            Object myObject = myClass.newInstance();
+            ourTeleCommand = (Command) myObject;
+        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException ex) {
+            logger.error("failed to load class; instantiating default stub for: {}", myName);
+            try {
+                ourTeleCommand = (Command) doNothingClass.getDeclaredConstructor().newInstance();
+            } catch (InstantiationException | IllegalAccessException | IllegalArgumentException
+                    | InvocationTargetException | NoSuchMethodException | SecurityException e) {
+                logger.error("failed to load do nothing class; instantiating stub for: {}", myName);
+                ourTeleCommand = new DoNothing();
+            }
+            SmartDashboard.putNumber(TelemetryNames.Climber.status, PKStatus.degraded.tlmValue);
+        }
+
+        defaultTeleCommand = ourTeleCommand;
+        SmartDashboard.putString(TelemetryNames.Climber.teleCommand, ourTeleCommand.getClass().getSimpleName());
+    }
+    
+}

--- a/src/main/java/frc/robot/subsystems/BaseSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/BaseSubsystem.java
@@ -34,8 +34,8 @@ public abstract class BaseSubsystem implements ISubsystem {
     protected final String myName;
 
     /** Objects to hold loaded default commands **/
-    protected static Command defaultAutoCommand;
-    protected static Command defaultTeleCommand;
+    protected Command defaultAutoCommand;
+    protected Command defaultTeleCommand;
 
     public BaseSubsystem(String name) {
         logger.info("constructing");
@@ -47,11 +47,13 @@ public abstract class BaseSubsystem implements ISubsystem {
 
     @Override
     public void setDefaultAutoCommand() {
+        logger.info("set default auto to {}", defaultAutoCommand.getName());
         setDefaultCommand(defaultAutoCommand);
     }
 
     @Override
     public void setDefaultTeleCommand() {
+        logger.info("set default teleop to {}", defaultTeleCommand.getName());
         setDefaultCommand(defaultTeleCommand);
     }
     

--- a/src/main/java/frc/robot/subsystems/BaseSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/BaseSubsystem.java
@@ -45,6 +45,16 @@ public abstract class BaseSubsystem implements ISubsystem {
         logger.info("constructed");
     }
 
+    @Override
+    public void setDefaultAutoCommand() {
+        setDefaultCommand(defaultAutoCommand);
+    }
+
+    @Override
+    public void setDefaultTeleCommand() {
+        setDefaultCommand(defaultTeleCommand);
+    }
+    
     /**
      * Called to load the default commands for the subsystem (both
      * autonomous and teleop); the values are determined from the
@@ -52,7 +62,7 @@ public abstract class BaseSubsystem implements ISubsystem {
      * 
      * @param doNothingClass - class to default to if not found or errors
      **/
-    protected void loadDefaultCommands(Class<PKCommandBase> doNothingClass) {
+    protected void loadDefaultCommands(Class<? extends PKCommandBase> doNothingClass) {
         logger.debug("loading for {}", myName);
 
         PKProperties props = PropertiesManager.getInstance().getProperties(myName);

--- a/src/main/java/frc/robot/subsystems/BaseSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/BaseSubsystem.java
@@ -47,13 +47,13 @@ public abstract class BaseSubsystem implements ISubsystem {
 
     @Override
     public void setDefaultAutoCommand() {
-        logger.info("set default auto to {}", defaultAutoCommand.getName());
+        logger.info("{} set default auto to {}", myName, defaultAutoCommand.getName());
         setDefaultCommand(defaultAutoCommand);
     }
 
     @Override
     public void setDefaultTeleCommand() {
-        logger.info("set default teleop to {}", defaultTeleCommand.getName());
+        logger.info("{} set default teleop to {}", myName, defaultTeleCommand.getName());
         setDefaultCommand(defaultTeleCommand);
     }
     
@@ -65,25 +65,23 @@ public abstract class BaseSubsystem implements ISubsystem {
      * @param doNothingClass - class to default to if not found or errors
      **/
     protected void loadDefaultCommands(Class<? extends PKCommandBase> doNothingClass) {
-        logger.debug("loading for {}", myName);
-
         PKProperties props = PropertiesManager.getInstance().getProperties(myName);
 
         String myAutoClassName = props.getString("autoCommandName");
+        logger.debug("{} attempting load of default auto {}", myName, myAutoClassName);
         if (myAutoClassName.isEmpty()) {
             logger.info("no class specified; go with subsystem default (do nothing)");
             myAutoClassName = new StringBuilder().append(myName).append("DoNothing").toString();
         }
         defaultAutoCommand = loadCommandClass(myAutoClassName, doNothingClass);
-        SmartDashboard.putString(TelemetryNames.Climber.autoCommand, defaultAutoCommand.getClass().getSimpleName());
 
         String myTeleClassName = props.getString("teleCommandName");
+        logger.debug("{} attempting load of default teleop {}", myName, myTeleClassName);
         if (myTeleClassName.isEmpty()) {
             logger.info("no class specified; go with subsystem default (do nothing)");
             myTeleClassName = new StringBuilder().append(myName).append("DoNothing").toString();
         }
         defaultTeleCommand = loadCommandClass(myTeleClassName, doNothingClass);
-        SmartDashboard.putString(TelemetryNames.Climber.teleCommand, defaultTeleCommand.getClass().getSimpleName());
     }
 
     /**
@@ -92,9 +90,9 @@ public abstract class BaseSubsystem implements ISubsystem {
      * any errors. If all else fails, then return an instance of the base
      * <code>DoNothingClass</code>.
      * 
-     * @param nameOfClass
-     * @param doNothingClass
-     * @return
+     * @param nameOfClass - name of class to load
+     * @param doNothingClass - default command class to use ('do nothing')
+     * @return class successfully loaded
      */
     private PKCommandBase loadCommandClass(String nameOfClass, Class<? extends PKCommandBase> doNothingClass) {
         String myPkgName = doNothingClass.getPackage().getName();

--- a/src/main/java/frc/robot/subsystems/ISubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ISubsystem.java
@@ -8,9 +8,11 @@
 
 package frc.robot.subsystems;
 
+
 import edu.wpi.first.wpilibj2.command.Subsystem;
 
 import frc.robot.telemetry.ITelemetryProvider;
+
 
 /**
  * Note that this now extends the official <i>WPILib</i> interface of
@@ -21,22 +23,27 @@ import frc.robot.telemetry.ITelemetryProvider;
 public interface ISubsystem extends Subsystem, ITelemetryProvider {
 
     /**
-     * Called to load the default commands for the subsystem; the values are
-     * determined from the properties file and loaded dynamically.
+     * Called to load the default commands for the subsystem (both
+     * autonomous and teleop); the values are determined from the
+     * properties file and loaded dynamically.
      **/
-    public void loadDefaultCommand();
+    public void loadDefaultCommands();
 
     /**
-     * Loads the default auto command. Needs to be called prior to starting to
-     * execute the actual autonomous periodic code.
+     * Sets the default command for the subsystem to be the previously
+     * loaded auto command. Called at the initialization of the mode;
+     * must be prior to actually starting to execute the actual autonomous
+     * periodic code.
      */
-    public void loadDefaultAutoCommand();
+    public void setDefaultAutoCommand();
 
     /**
-     * Loads the default teleoperated command. Needs tp be called prior to starting
-     * to execute the actual teleoperated periodic code.
+     * Sets the default command for the subsystem to be the previously
+     * loaded teleop command. Called at the initialization of the mode;
+     * must be prior to actually starting to execute the actual teleop
+     * periodic code.
      */
-    public void loadDefaultTeleCommand();
+    public void setDefaultTeleCommand();
 
     /**
      * Called to validate that the calibration values in the properties match the

--- a/src/main/java/frc/robot/subsystems/SubsystemFactory.java
+++ b/src/main/java/frc/robot/subsystems/SubsystemFactory.java
@@ -111,7 +111,7 @@ public class SubsystemFactory {
 
         // Load the default commands now that all subsystems are created
         for (ISubsystem ss : subsystems) {
-            ss.loadDefaultCommand();
+            ss.loadDefaultCommands();
         }
 
         logger.info("constructed");

--- a/src/main/java/frc/robot/subsystems/SubsystemFactory.java
+++ b/src/main/java/frc/robot/subsystems/SubsystemFactory.java
@@ -8,10 +8,12 @@
 
 package frc.robot.subsystems;
 
+
 import java.util.ArrayList;
 import java.util.List;
 
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+
 import frc.robot.subsystems.climber.ClimberFactory;
 import frc.robot.subsystems.drive.DriveFactory;
 import frc.robot.subsystems.elevator.ElevatorFactory;
@@ -25,6 +27,7 @@ import frc.robot.utils.PKStatus;
 
 import riolog.PKLogger;
 import riolog.RioLogger;
+
 
 /**
  * 

--- a/src/main/java/frc/robot/subsystems/climber/BaseClimberSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/climber/BaseClimberSubsystem.java
@@ -38,6 +38,8 @@ abstract class BaseClimberSubsystem extends BaseSubsystem implements IClimberSub
     @Override
     public void loadDefaultCommands() {
         loadDefaultCommands(ClimberDoNothing.class);
+        SmartDashboard.putString(TelemetryNames.Climber.autoCommand, defaultAutoCommand.getClass().getSimpleName());
+        SmartDashboard.putString(TelemetryNames.Climber.teleCommand, defaultTeleCommand.getClass().getSimpleName());
     }
 
     protected void loadPreferences() {

--- a/src/main/java/frc/robot/subsystems/climber/BaseClimberSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/climber/BaseClimberSubsystem.java
@@ -8,6 +8,7 @@
 
 package frc.robot.subsystems.climber;
 
+
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
@@ -15,6 +16,7 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.commands.climber.ClimberDoNothing;
 import frc.robot.properties.PKProperties;
 import frc.robot.properties.PropertiesManager;
+import frc.robot.subsystems.BaseSubsystem;
 import frc.robot.subsystems.SubsystemNames;
 import frc.robot.telemetry.TelemetryNames;
 import frc.robot.utils.PKStatus;
@@ -22,81 +24,25 @@ import frc.robot.utils.PKStatus;
 import riolog.PKLogger;
 import riolog.RioLogger;
 
+
 /**
  * Add your docs here.
  */
-abstract class BaseClimberSubsystem extends SubsystemBase implements IClimberSubsystem {
+abstract class BaseClimberSubsystem extends BaseSubsystem implements IClimberSubsystem {
 
     /** Our classes' logger **/
     private static final PKLogger logger = RioLogger.getLogger(BaseClimberSubsystem.class.getName());
 
-    /** Our subsystem's name **/
-    protected static final String myName = SubsystemNames.climberName;
-
     BaseClimberSubsystem() {
+        super(SubsystemNames.climberName);
         logger.info("constructing");
 
         logger.info("constructed");
     }
 
-    /** Objects to hold loaded default commands **/
-    private static Command defaultAutoCommand;
-    private static Command defaultTeleCommand;
-
     @Override
     public void loadDefaultCommands() {
-        PKProperties props = PropertiesManager.getInstance().getProperties(myName);
-        String myAutoClassName = props.getString("autoCommandName");
-        if (myAutoClassName.isEmpty()) {
-            logger.info("no class specified; go with subsystem default (do nothing)");
-            myAutoClassName = new StringBuilder().append(myName).append("DoNothing").toString();
-        }
-        String myPkgName = ClimberDoNothing.class.getPackage().getName();
-        String classToLoad = new StringBuilder().append(myPkgName).append(".").append(myAutoClassName).toString();
-        logger.debug("class to load: {}", classToLoad);
-
-        logger.info("constructing {} for {} subsystem", myAutoClassName, myName);
-        Command ourAutoCommand;
-        try {
-            @SuppressWarnings("rawtypes")
-            Class myClass = Class.forName(classToLoad);
-            @SuppressWarnings("deprecation")
-            Object myObject = myClass.newInstance();
-            ourAutoCommand = (Command) myObject;
-        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException ex) {
-            logger.error("failed to load class; instantiating default stub for: {}", myName);
-            ourAutoCommand = (Command) new ClimberDoNothing();
-            SmartDashboard.putNumber(TelemetryNames.Climber.status, PKStatus.degraded.tlmValue);
-        }
-
-        defaultAutoCommand = ourAutoCommand;
-        SmartDashboard.putString(TelemetryNames.Climber.autoCommand, ourAutoCommand.getClass().getSimpleName());
-
-        String myTeleClassName = props.getString("teleCommandName");
-        if (myTeleClassName.isEmpty()) {
-            logger.info("no class specified; go with subsystem default (do nothing)");
-            myTeleClassName = new StringBuilder().append(myName).append("DoNothing").toString();
-        }
-        myPkgName = ClimberDoNothing.class.getPackage().getName();
-        classToLoad = new StringBuilder().append(myPkgName).append(".").append(myTeleClassName).toString();
-        logger.debug("class to load: {}", classToLoad);
-
-        logger.info("constructing {} for {} subsystem", myTeleClassName, myName);
-        Command ourTeleCommand;
-        try {
-            @SuppressWarnings("rawtypes")
-            Class myClass = Class.forName(classToLoad);
-            @SuppressWarnings("deprecation")
-            Object myObject = myClass.newInstance();
-            ourTeleCommand = (Command) myObject;
-        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException ex) {
-            logger.error("failed to load class; instantiating default stub for: {}", myName);
-            ourTeleCommand = (Command) new ClimberDoNothing();
-            SmartDashboard.putNumber(TelemetryNames.Climber.status, PKStatus.degraded.tlmValue);
-        }
-
-        defaultTeleCommand = ourTeleCommand;
-        SmartDashboard.putString(TelemetryNames.Climber.teleCommand, ourTeleCommand.getClass().getSimpleName());
+        loadDefaultCommands(ClimberDoNothing);
     }
 
     @Override

--- a/src/main/java/frc/robot/subsystems/climber/BaseClimberSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/climber/BaseClimberSubsystem.java
@@ -10,16 +10,11 @@ package frc.robot.subsystems.climber;
 
 
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
-import edu.wpi.first.wpilibj2.command.Command;
-import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 import frc.robot.commands.climber.ClimberDoNothing;
-import frc.robot.properties.PKProperties;
-import frc.robot.properties.PropertiesManager;
 import frc.robot.subsystems.BaseSubsystem;
 import frc.robot.subsystems.SubsystemNames;
 import frc.robot.telemetry.TelemetryNames;
-import frc.robot.utils.PKStatus;
 
 import riolog.PKLogger;
 import riolog.RioLogger;
@@ -42,17 +37,7 @@ abstract class BaseClimberSubsystem extends BaseSubsystem implements IClimberSub
 
     @Override
     public void loadDefaultCommands() {
-        loadDefaultCommands(ClimberDoNothing);
-    }
-
-    @Override
-    public void setDefaultAutoCommand() {
-        setDefaultCommand(defaultAutoCommand);
-    }
-
-    @Override
-    public void setDefaultTeleCommand() {
-        setDefaultCommand(defaultTeleCommand);
+        loadDefaultCommands(ClimberDoNothing.class);
     }
 
     protected void loadPreferences() {

--- a/src/main/java/frc/robot/subsystems/climber/BaseClimberSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/climber/BaseClimberSubsystem.java
@@ -44,7 +44,7 @@ abstract class BaseClimberSubsystem extends SubsystemBase implements IClimberSub
     private static Command defaultTeleCommand;
 
     @Override
-    public void loadDefaultCommand() {
+    public void loadDefaultCommands() {
         PKProperties props = PropertiesManager.getInstance().getProperties(myName);
         String myAutoClassName = props.getString("autoCommandName");
         if (myAutoClassName.isEmpty()) {
@@ -100,12 +100,12 @@ abstract class BaseClimberSubsystem extends SubsystemBase implements IClimberSub
     }
 
     @Override
-    public void loadDefaultAutoCommand() {
+    public void setDefaultAutoCommand() {
         setDefaultCommand(defaultAutoCommand);
     }
 
     @Override
-    public void loadDefaultTeleCommand() {
+    public void setDefaultTeleCommand() {
         setDefaultCommand(defaultTeleCommand);
     }
 

--- a/src/main/java/frc/robot/subsystems/drive/BaseDriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/drive/BaseDriveSubsystem.java
@@ -54,6 +54,8 @@ abstract class BaseDriveSubsystem extends BaseSubsystem implements IDriveSubsyst
     @Override
     public void loadDefaultCommands() {
         loadDefaultCommands(DriveDoNothing.class);
+        SmartDashboard.putString(TelemetryNames.Drive.autoCommand, defaultAutoCommand.getClass().getSimpleName());
+        SmartDashboard.putString(TelemetryNames.Drive.teleCommand, defaultTeleCommand.getClass().getSimpleName());
     }
 
     protected void loadPreferences() {

--- a/src/main/java/frc/robot/subsystems/drive/BaseDriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/drive/BaseDriveSubsystem.java
@@ -11,15 +11,11 @@ package frc.robot.subsystems.drive;
 
 import edu.wpi.first.wpilibj.Preferences;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
-import edu.wpi.first.wpilibj2.command.Command;
-import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 import frc.robot.commands.drive.DriveDoNothing;
-import frc.robot.properties.PKProperties;
-import frc.robot.properties.PropertiesManager;
+import frc.robot.subsystems.BaseSubsystem;
 import frc.robot.subsystems.SubsystemNames;
 import frc.robot.telemetry.TelemetryNames;
-import frc.robot.utils.PKStatus;
 
 import riolog.PKLogger;
 import riolog.RioLogger;
@@ -28,13 +24,10 @@ import riolog.RioLogger;
 /**
  * Add your docs here.
  */
-abstract class BaseDriveSubsystem extends SubsystemBase implements IDriveSubsystem {
+abstract class BaseDriveSubsystem extends BaseSubsystem implements IDriveSubsystem {
 
     /** Our classes' logger **/
     private static final PKLogger logger = RioLogger.getLogger(BaseDriveSubsystem.class.getName());
-
-    /** Our subsystem's name **/
-    protected static final String myName = SubsystemNames.driveName;
 
     /** Default preferences for subystem **/
     private final double default_pid_P = 0.0;
@@ -52,79 +45,15 @@ abstract class BaseDriveSubsystem extends SubsystemBase implements IDriveSubsyst
     protected double ramp = 0;
 
     BaseDriveSubsystem() {
+        super(SubsystemNames.driveName);
         logger.info("constructing");
 
         logger.info("constructed");
     }
 
-    /** Objects to hold loaded default commands **/
-    private static Command defaultAutoCommand;
-    private static Command defaultTeleCommand;
-
     @Override
     public void loadDefaultCommands() {
-        PKProperties props = PropertiesManager.getInstance().getProperties(myName);
-        String myAutoClassName = props.getString("autoCommandName");
-        if (myAutoClassName.isEmpty()) {
-            logger.info("no class specified; go with subsystem default (do nothing)");
-            myAutoClassName = new StringBuilder().append(myName).append("DoNothing").toString();
-        }
-        String myPkgName = DriveDoNothing.class.getPackage().getName();
-        String classToLoad = new StringBuilder().append(myPkgName).append(".").append(myAutoClassName).toString();
-        logger.debug("class to load: {}", classToLoad);
-
-        logger.info("constructing {} for {} subsystem", myAutoClassName, myName);
-        Command ourAutoCommand;
-        try {
-            @SuppressWarnings("rawtypes")
-            Class myClass = Class.forName(classToLoad);
-            @SuppressWarnings("deprecation")
-            Object myObject = myClass.newInstance();
-            ourAutoCommand = (Command) myObject;
-        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException ex) {
-            logger.error("failed to load class; instantiating default stub for: {}", myName);
-            ourAutoCommand = (Command) new DriveDoNothing();
-            SmartDashboard.putNumber(TelemetryNames.Drive.status, PKStatus.degraded.tlmValue);
-        }
-
-        defaultAutoCommand = ourAutoCommand;
-        SmartDashboard.putString(TelemetryNames.Drive.autoCommand, ourAutoCommand.getClass().getSimpleName());
-
-        String myTeleClassName = props.getString("teleCommandName");
-        if (myTeleClassName.isEmpty()) {
-            logger.info("no class specified; go with subsystem default (do nothing)");
-            myTeleClassName = new StringBuilder().append(myName).append("DoNothing").toString();
-        }
-        myPkgName = DriveDoNothing.class.getPackage().getName();
-        classToLoad = new StringBuilder().append(myPkgName).append(".").append(myTeleClassName).toString();
-        logger.debug("class to load: {}", classToLoad);
-
-        logger.info("constructing {} for {} subsystem", myTeleClassName, myName);
-        Command ourTeleCommand;
-        try {
-            @SuppressWarnings("rawtypes")
-            Class myClass = Class.forName(classToLoad);
-            @SuppressWarnings("deprecation")
-            Object myObject = myClass.newInstance();
-            ourTeleCommand = (Command) myObject;
-        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException ex) {
-            logger.error("failed to load class; instantiating default stub for: {}", myName);
-            ourTeleCommand = (Command) new DriveDoNothing();
-            SmartDashboard.putNumber(TelemetryNames.Drive.status, PKStatus.degraded.tlmValue);
-        }
-
-        defaultTeleCommand = ourTeleCommand;
-        SmartDashboard.putString(TelemetryNames.Drive.teleCommand, ourTeleCommand.getClass().getSimpleName());
-    }
-
-    @Override
-    public void setDefaultAutoCommand() {
-        setDefaultCommand(defaultAutoCommand);
-    }
-
-    @Override
-    public void setDefaultTeleCommand() {
-        setDefaultCommand(defaultTeleCommand);
+        loadDefaultCommands(DriveDoNothing.class);
     }
 
     protected void loadPreferences() {

--- a/src/main/java/frc/robot/subsystems/drive/BaseDriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/drive/BaseDriveSubsystem.java
@@ -62,7 +62,7 @@ abstract class BaseDriveSubsystem extends SubsystemBase implements IDriveSubsyst
     private static Command defaultTeleCommand;
 
     @Override
-    public void loadDefaultCommand() {
+    public void loadDefaultCommands() {
         PKProperties props = PropertiesManager.getInstance().getProperties(myName);
         String myAutoClassName = props.getString("autoCommandName");
         if (myAutoClassName.isEmpty()) {
@@ -118,12 +118,12 @@ abstract class BaseDriveSubsystem extends SubsystemBase implements IDriveSubsyst
     }
 
     @Override
-    public void loadDefaultAutoCommand() {
+    public void setDefaultAutoCommand() {
         setDefaultCommand(defaultAutoCommand);
     }
 
     @Override
-    public void loadDefaultTeleCommand() {
+    public void setDefaultTeleCommand() {
         setDefaultCommand(defaultTeleCommand);
     }
 

--- a/src/main/java/frc/robot/subsystems/elevator/BaseElevatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/elevator/BaseElevatorSubsystem.java
@@ -46,7 +46,7 @@ abstract class BaseElevatorSubsystem extends SubsystemBase implements IElevatorS
     private static Command defaultTeleCommand;
 
     @Override
-    public void loadDefaultCommand() {
+    public void loadDefaultCommands() {
         PKProperties props = PropertiesManager.getInstance().getProperties(myName);
         String myAutoClassName = props.getString("autoCommandName");
         if (myAutoClassName.isEmpty()) {
@@ -102,12 +102,12 @@ abstract class BaseElevatorSubsystem extends SubsystemBase implements IElevatorS
     }
 
     @Override
-    public void loadDefaultAutoCommand() {
+    public void setDefaultAutoCommand() {
         setDefaultCommand(defaultAutoCommand);
     }
 
     @Override
-    public void loadDefaultTeleCommand() {
+    public void setDefaultTeleCommand() {
         setDefaultCommand(defaultTeleCommand);
     }
 

--- a/src/main/java/frc/robot/subsystems/elevator/BaseElevatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/elevator/BaseElevatorSubsystem.java
@@ -38,6 +38,8 @@ abstract class BaseElevatorSubsystem extends BaseSubsystem implements IElevatorS
     @Override
     public void loadDefaultCommands() {
         loadDefaultCommands(ElevatorDoNothing.class);
+        SmartDashboard.putString(TelemetryNames.Elevator.autoCommand, defaultAutoCommand.getClass().getSimpleName());
+        SmartDashboard.putString(TelemetryNames.Elevator.teleCommand, defaultTeleCommand.getClass().getSimpleName());
     }
 
     protected void loadPreferences() {

--- a/src/main/java/frc/robot/subsystems/elevator/BaseElevatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/elevator/BaseElevatorSubsystem.java
@@ -10,15 +10,11 @@ package frc.robot.subsystems.elevator;
 
 
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
-import edu.wpi.first.wpilibj2.command.Command;
-import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 import frc.robot.commands.elevator.ElevatorDoNothing;
-import frc.robot.properties.PKProperties;
-import frc.robot.properties.PropertiesManager;
+import frc.robot.subsystems.BaseSubsystem;
 import frc.robot.subsystems.SubsystemNames;
 import frc.robot.telemetry.TelemetryNames;
-import frc.robot.utils.PKStatus;
 
 import riolog.PKLogger;
 import riolog.RioLogger;
@@ -27,88 +23,21 @@ import riolog.RioLogger;
 /**
  * Add your docs here.
  */
-abstract class BaseElevatorSubsystem extends SubsystemBase implements IElevatorSubsystem {
+abstract class BaseElevatorSubsystem extends BaseSubsystem implements IElevatorSubsystem {
 
     /** Our classes' logger **/
     private static final PKLogger logger = RioLogger.getLogger(BaseElevatorSubsystem.class.getName());
 
-    /** Our subsystem's name **/
-    protected static final String myName = SubsystemNames.elevatorName;
-
     BaseElevatorSubsystem() {
+        super(SubsystemNames.elevatorName);
         logger.info("constructing");
 
         logger.info("constructed");
     }
 
-    /** Objects to hold loaded default commands **/
-    private static Command defaultAutoCommand;
-    private static Command defaultTeleCommand;
-
     @Override
     public void loadDefaultCommands() {
-        PKProperties props = PropertiesManager.getInstance().getProperties(myName);
-        String myAutoClassName = props.getString("autoCommandName");
-        if (myAutoClassName.isEmpty()) {
-            logger.info("no class specified; go with subsystem default (do nothing)");
-            myAutoClassName = new StringBuilder().append(myName).append("DoNothing").toString();
-        }
-        String myPkgName = ElevatorDoNothing.class.getPackage().getName();
-        String classToLoad = new StringBuilder().append(myPkgName).append(".").append(myAutoClassName).toString();
-        logger.debug("class to load: {}", classToLoad);
-
-        logger.info("constructing {} for {} subsystem", myAutoClassName, myName);
-        Command ourAutoCommand;
-        try {
-            @SuppressWarnings("rawtypes")
-            Class myClass = Class.forName(classToLoad);
-            @SuppressWarnings("deprecation")
-            Object myObject = myClass.newInstance();
-            ourAutoCommand = (Command) myObject;
-        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException ex) {
-            logger.error("failed to load class; instantiating default stub for: {}", myName);
-            ourAutoCommand = (Command) new ElevatorDoNothing();
-            SmartDashboard.putNumber(TelemetryNames.Elevator.status, PKStatus.degraded.tlmValue);
-        }
-
-        defaultAutoCommand = ourAutoCommand;
-        SmartDashboard.putString(TelemetryNames.Elevator.autoCommand, ourAutoCommand.getClass().getSimpleName());
-
-        String myTeleClassName = props.getString("teleCommandName");
-        if (myTeleClassName.isEmpty()) {
-            logger.info("no class specified; go with subsystem default (do nothing)");
-            myTeleClassName = new StringBuilder().append(myName).append("DoNothing").toString();
-        }
-        myPkgName = ElevatorDoNothing.class.getPackage().getName();
-        classToLoad = new StringBuilder().append(myPkgName).append(".").append(myTeleClassName).toString();
-        logger.debug("class to load: {}", classToLoad);
-
-        logger.info("constructing {} for {} subsystem", myTeleClassName, myName);
-        Command ourTeleCommand;
-        try {
-            @SuppressWarnings("rawtypes")
-            Class myClass = Class.forName(classToLoad);
-            @SuppressWarnings("deprecation")
-            Object myObject = myClass.newInstance();
-            ourTeleCommand = (Command) myObject;
-        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException ex) {
-            logger.error("failed to load class; instantiating default stub for: {}", myName);
-            ourTeleCommand = (Command) new ElevatorDoNothing();
-            SmartDashboard.putNumber(TelemetryNames.Elevator.status, PKStatus.degraded.tlmValue);
-        }
-
-        defaultTeleCommand = ourTeleCommand;
-        SmartDashboard.putString(TelemetryNames.Elevator.teleCommand, ourTeleCommand.getClass().getSimpleName());
-    }
-
-    @Override
-    public void setDefaultAutoCommand() {
-        setDefaultCommand(defaultAutoCommand);
-    }
-
-    @Override
-    public void setDefaultTeleCommand() {
-        setDefaultCommand(defaultTeleCommand);
+        loadDefaultCommands(ElevatorDoNothing.class);
     }
 
     protected void loadPreferences() {

--- a/src/main/java/frc/robot/subsystems/incrementer/BaseIncrementerSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/incrementer/BaseIncrementerSubsystem.java
@@ -10,15 +10,11 @@ package frc.robot.subsystems.incrementer;
 
 
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
-import edu.wpi.first.wpilibj2.command.Command;
-import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 import frc.robot.commands.incrementer.IncrementerDoNothing;
-import frc.robot.properties.PKProperties;
-import frc.robot.properties.PropertiesManager;
+import frc.robot.subsystems.BaseSubsystem;
 import frc.robot.subsystems.SubsystemNames;
 import frc.robot.telemetry.TelemetryNames;
-import frc.robot.utils.PKStatus;
 
 import riolog.PKLogger;
 import riolog.RioLogger;
@@ -27,88 +23,21 @@ import riolog.RioLogger;
 /**
  * Add your docs here.
  */
-abstract class BaseIncrementerSubsystem extends SubsystemBase implements IIncrementerSubsystem {
+abstract class BaseIncrementerSubsystem extends BaseSubsystem implements IIncrementerSubsystem {
 
     /** Our classes' logger **/
     private static final PKLogger logger = RioLogger.getLogger(BaseIncrementerSubsystem.class.getName());
 
-    /** Our subsystem's name **/
-    protected static final String myName = SubsystemNames.incrementerName;
-
     BaseIncrementerSubsystem() {
+        super(SubsystemNames.incrementerName);
         logger.info("constructing");
 
         logger.info("constructed");
     }
 
-    /** Objects to hold loaded default commands **/
-    private static Command defaultAutoCommand;
-    private static Command defaultTeleCommand;
-
     @Override
     public void loadDefaultCommands() {
-        PKProperties props = PropertiesManager.getInstance().getProperties(myName);
-        String myAutoClassName = props.getString("autoCommandName");
-        if (myAutoClassName.isEmpty()) {
-            logger.info("no class specified; go with subsystem default (do nothing)");
-            myAutoClassName = new StringBuilder().append(myName).append("DoNothing").toString();
-        }
-        String myPkgName = IncrementerDoNothing.class.getPackage().getName();
-        String classToLoad = new StringBuilder().append(myPkgName).append(".").append(myAutoClassName).toString();
-        logger.debug("class to load: {}", classToLoad);
-
-        logger.info("constructing {} for {} subsystem", myAutoClassName, myName);
-        Command ourAutoCommand;
-        try {
-            @SuppressWarnings("rawtypes")
-            Class myClass = Class.forName(classToLoad);
-            @SuppressWarnings("deprecation")
-            Object myObject = myClass.newInstance();
-            ourAutoCommand = (Command) myObject;
-        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException ex) {
-            logger.error("failed to load class; instantiating default stub for: {}", myName);
-            ourAutoCommand = (Command) new IncrementerDoNothing();
-            SmartDashboard.putNumber(TelemetryNames.Incrementer.status, PKStatus.degraded.tlmValue);
-        }
-
-        defaultAutoCommand = ourAutoCommand;
-        SmartDashboard.putString(TelemetryNames.Incrementer.autoCommand, ourAutoCommand.getClass().getSimpleName());
-
-        String myTeleClassName = props.getString("teleCommandName");
-        if (myTeleClassName.isEmpty()) {
-            logger.info("no class specified; go with subsystem default (do nothing)");
-            myTeleClassName = new StringBuilder().append(myName).append("DoNothing").toString();
-        }
-        myPkgName = IncrementerDoNothing.class.getPackage().getName();
-        classToLoad = new StringBuilder().append(myPkgName).append(".").append(myTeleClassName).toString();
-        logger.debug("class to load: {}", classToLoad);
-
-        logger.info("constructing {} for {} subsystem", myTeleClassName, myName);
-        Command ourTeleCommand;
-        try {
-            @SuppressWarnings("rawtypes")
-            Class myClass = Class.forName(classToLoad);
-            @SuppressWarnings("deprecation")
-            Object myObject = myClass.newInstance();
-            ourTeleCommand = (Command) myObject;
-        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException ex) {
-            logger.error("failed to load class; instantiating default stub for: {}", myName);
-            ourTeleCommand = (Command) new IncrementerDoNothing();
-            SmartDashboard.putNumber(TelemetryNames.Incrementer.status, PKStatus.degraded.tlmValue);
-        }
-
-        defaultTeleCommand = ourTeleCommand;
-        SmartDashboard.putString(TelemetryNames.Incrementer.teleCommand, ourTeleCommand.getClass().getSimpleName());
-    }
-
-    @Override
-    public void setDefaultAutoCommand() {
-        setDefaultCommand(defaultAutoCommand);
-    }
-
-    @Override
-    public void setDefaultTeleCommand() {
-        setDefaultCommand(defaultTeleCommand);
+        loadDefaultCommands(IncrementerDoNothing.class);
     }
 
     private double tlmSpeed = 0.0;

--- a/src/main/java/frc/robot/subsystems/incrementer/BaseIncrementerSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/incrementer/BaseIncrementerSubsystem.java
@@ -38,6 +38,8 @@ abstract class BaseIncrementerSubsystem extends BaseSubsystem implements IIncrem
     @Override
     public void loadDefaultCommands() {
         loadDefaultCommands(IncrementerDoNothing.class);
+        SmartDashboard.putString(TelemetryNames.Incrementer.autoCommand, defaultAutoCommand.getClass().getSimpleName());
+        SmartDashboard.putString(TelemetryNames.Incrementer.teleCommand, defaultTeleCommand.getClass().getSimpleName());
     }
 
     private double tlmSpeed = 0.0;

--- a/src/main/java/frc/robot/subsystems/incrementer/BaseIncrementerSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/incrementer/BaseIncrementerSubsystem.java
@@ -46,7 +46,7 @@ abstract class BaseIncrementerSubsystem extends SubsystemBase implements IIncrem
     private static Command defaultTeleCommand;
 
     @Override
-    public void loadDefaultCommand() {
+    public void loadDefaultCommands() {
         PKProperties props = PropertiesManager.getInstance().getProperties(myName);
         String myAutoClassName = props.getString("autoCommandName");
         if (myAutoClassName.isEmpty()) {
@@ -102,12 +102,12 @@ abstract class BaseIncrementerSubsystem extends SubsystemBase implements IIncrem
     }
 
     @Override
-    public void loadDefaultAutoCommand() {
+    public void setDefaultAutoCommand() {
         setDefaultCommand(defaultAutoCommand);
     }
 
     @Override
-    public void loadDefaultTeleCommand() {
+    public void setDefaultTeleCommand() {
         setDefaultCommand(defaultTeleCommand);
     }
 

--- a/src/main/java/frc/robot/subsystems/intake/BaseIntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/intake/BaseIntakeSubsystem.java
@@ -8,105 +8,36 @@
 
 package frc.robot.subsystems.intake;
 
+
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
-import edu.wpi.first.wpilibj2.command.Command;
-import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 import frc.robot.commands.intake.IntakeDoNothing;
-import frc.robot.properties.PKProperties;
-import frc.robot.properties.PropertiesManager;
+import frc.robot.subsystems.BaseSubsystem;
 import frc.robot.subsystems.SubsystemNames;
 import frc.robot.telemetry.TelemetryNames;
-import frc.robot.utils.PKStatus;
 
 import riolog.PKLogger;
 import riolog.RioLogger;
 
+
 /**
  * Add your docs here.
  */
-abstract class BaseIntakeSubsystem extends SubsystemBase implements IIntakeSubsystem {
+abstract class BaseIntakeSubsystem extends BaseSubsystem implements IIntakeSubsystem {
 
     /** Our classes' logger **/
     private static final PKLogger logger = RioLogger.getLogger(BaseIntakeSubsystem.class.getName());
 
-    /** Our subsystem's name **/
-    protected static final String myName = SubsystemNames.intakeName;
-
     BaseIntakeSubsystem() {
+        super(SubsystemNames.intakeName);
         logger.info("constructing");
 
         logger.info("constructed");
     }
 
-    /** Objects to hold loaded default commands **/
-    private static Command defaultAutoCommand;
-    private static Command defaultTeleCommand;
-
     @Override
     public void loadDefaultCommands() {
-        PKProperties props = PropertiesManager.getInstance().getProperties(myName);
-        String myAutoClassName = props.getString("autoCommandName");
-        if (myAutoClassName.isEmpty()) {
-            logger.info("no class specified; go with subsystem default (do nothing)");
-            myAutoClassName = new StringBuilder().append(myName).append("DoNothing").toString();
-        }
-        String myPkgName = IntakeDoNothing.class.getPackage().getName();
-        String classToLoad = new StringBuilder().append(myPkgName).append(".").append(myAutoClassName).toString();
-        logger.debug("class to load: {}", classToLoad);
-
-        logger.info("constructing {} for {} subsystem", myAutoClassName, myName);
-        Command ourAutoCommand;
-        try {
-            @SuppressWarnings("rawtypes")
-            Class myClass = Class.forName(classToLoad);
-            @SuppressWarnings("deprecation")
-            Object myObject = myClass.newInstance();
-            ourAutoCommand = (Command) myObject;
-        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException ex) {
-            logger.error("failed to load class; instantiating default stub for: {}", myName);
-            ourAutoCommand = (Command) new IntakeDoNothing();
-            SmartDashboard.putNumber(TelemetryNames.Intake.status, PKStatus.degraded.tlmValue);
-        }
-
-        defaultAutoCommand = ourAutoCommand;
-        SmartDashboard.putString(TelemetryNames.Intake.autoCommand, ourAutoCommand.getClass().getSimpleName());
-
-        String myTeleClassName = props.getString("teleCommandName");
-        if (myTeleClassName.isEmpty()) {
-            logger.info("no class specified; go with subsystem default (do nothing)");
-            myTeleClassName = new StringBuilder().append(myName).append("DoNothing").toString();
-        }
-        myPkgName = IntakeDoNothing.class.getPackage().getName();
-        classToLoad = new StringBuilder().append(myPkgName).append(".").append(myTeleClassName).toString();
-        logger.debug("class to load: {}", classToLoad);
-
-        logger.info("constructing {} for {} subsystem", myTeleClassName, myName);
-        Command ourTeleCommand;
-        try {
-            @SuppressWarnings("rawtypes")
-            Class myClass = Class.forName(classToLoad);
-            @SuppressWarnings("deprecation")
-            Object myObject = myClass.newInstance();
-            ourTeleCommand = (Command) myObject;
-        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException ex) {
-            logger.error("failed to load class; instantiating default stub for: {}", myName);
-            ourTeleCommand = (Command) new IntakeDoNothing();
-            SmartDashboard.putNumber(TelemetryNames.Intake.status, PKStatus.degraded.tlmValue);
-        }
-
-        defaultTeleCommand = ourTeleCommand;
-        SmartDashboard.putString(TelemetryNames.Intake.teleCommand, ourTeleCommand.getClass().getSimpleName());
-    }
-
-    @Override
-    public void setDefaultAutoCommand() {
-        setDefaultCommand(defaultAutoCommand);
-    }
-
-    @Override
-    public void setDefaultTeleCommand() {
-        setDefaultCommand(defaultTeleCommand);
+        loadDefaultCommands(IntakeDoNothing.class);
     }
 
     protected void loadPreferences() {

--- a/src/main/java/frc/robot/subsystems/intake/BaseIntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/intake/BaseIntakeSubsystem.java
@@ -38,6 +38,8 @@ abstract class BaseIntakeSubsystem extends BaseSubsystem implements IIntakeSubsy
     @Override
     public void loadDefaultCommands() {
         loadDefaultCommands(IntakeDoNothing.class);
+        SmartDashboard.putString(TelemetryNames.Intake.autoCommand, defaultAutoCommand.getClass().getSimpleName());
+        SmartDashboard.putString(TelemetryNames.Intake.teleCommand, defaultTeleCommand.getClass().getSimpleName());
     }
 
     protected void loadPreferences() {

--- a/src/main/java/frc/robot/subsystems/intake/BaseIntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/intake/BaseIntakeSubsystem.java
@@ -44,7 +44,7 @@ abstract class BaseIntakeSubsystem extends SubsystemBase implements IIntakeSubsy
     private static Command defaultTeleCommand;
 
     @Override
-    public void loadDefaultCommand() {
+    public void loadDefaultCommands() {
         PKProperties props = PropertiesManager.getInstance().getProperties(myName);
         String myAutoClassName = props.getString("autoCommandName");
         if (myAutoClassName.isEmpty()) {
@@ -100,12 +100,12 @@ abstract class BaseIntakeSubsystem extends SubsystemBase implements IIntakeSubsy
     }
 
     @Override
-    public void loadDefaultAutoCommand() {
+    public void setDefaultAutoCommand() {
         setDefaultCommand(defaultAutoCommand);
     }
 
     @Override
-    public void loadDefaultTeleCommand() {
+    public void setDefaultTeleCommand() {
         setDefaultCommand(defaultTeleCommand);
     }
 

--- a/src/main/java/frc/robot/subsystems/shooter/BaseShooterSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/shooter/BaseShooterSubsystem.java
@@ -54,6 +54,8 @@ abstract class BaseShooterSubsystem extends BaseSubsystem implements IShooterSub
     @Override
     public void loadDefaultCommands() {
         loadDefaultCommands(ShooterDoNothing.class);
+        SmartDashboard.putString(TelemetryNames.Shooter.autoCommand, defaultAutoCommand.getClass().getSimpleName());
+        SmartDashboard.putString(TelemetryNames.Shooter.teleCommand, defaultTeleCommand.getClass().getSimpleName());
     }
 
     protected void loadPreferences() {

--- a/src/main/java/frc/robot/subsystems/shooter/BaseShooterSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/shooter/BaseShooterSubsystem.java
@@ -8,31 +8,26 @@
 
 package frc.robot.subsystems.shooter;
 
+
 import edu.wpi.first.wpilibj.Preferences;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
-import edu.wpi.first.wpilibj2.command.Command;
-import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 import frc.robot.commands.shooter.ShooterDoNothing;
-import frc.robot.properties.PKProperties;
-import frc.robot.properties.PropertiesManager;
+import frc.robot.subsystems.BaseSubsystem;
 import frc.robot.subsystems.SubsystemNames;
 import frc.robot.telemetry.TelemetryNames;
-import frc.robot.utils.PKStatus;
 
 import riolog.PKLogger;
 import riolog.RioLogger;
 
+
 /**
  * Add your docs here.
  */
-abstract class BaseShooterSubsystem extends SubsystemBase implements IShooterSubsystem {
+abstract class BaseShooterSubsystem extends BaseSubsystem implements IShooterSubsystem {
 
     /** Our classes' logger **/
     private static final PKLogger logger = RioLogger.getLogger(BaseShooterSubsystem.class.getName());
-
-    /** Our subsystem's name **/
-    protected static final String myName = SubsystemNames.shooterName;
 
     /** Default preferences for subystem **/
     private final double default_pid_P = 0.0;
@@ -50,79 +45,15 @@ abstract class BaseShooterSubsystem extends SubsystemBase implements IShooterSub
     protected double scale = 1;
 
     BaseShooterSubsystem() {
+        super(SubsystemNames.shooterName);
         logger.info("constructing");
 
         logger.info("constructed");
     }
 
-    /** Objects to hold loaded default commands **/
-    private static Command defaultAutoCommand;
-    private static Command defaultTeleCommand;
-
     @Override
     public void loadDefaultCommands() {
-        PKProperties props = PropertiesManager.getInstance().getProperties(myName);
-        String myAutoClassName = props.getString("autoCommandName");
-        if (myAutoClassName.isEmpty()) {
-            logger.info("no class specified; go with subsystem default (do nothing)");
-            myAutoClassName = new StringBuilder().append(myName).append("DoNothing").toString();
-        }
-        String myPkgName = ShooterDoNothing.class.getPackage().getName();
-        String classToLoad = new StringBuilder().append(myPkgName).append(".").append(myAutoClassName).toString();
-        logger.debug("class to load: {}", classToLoad);
-
-        logger.info("constructing {} for {} subsystem", myAutoClassName, myName);
-        Command ourAutoCommand;
-        try {
-            @SuppressWarnings("rawtypes")
-            Class myClass = Class.forName(classToLoad);
-            @SuppressWarnings("deprecation")
-            Object myObject = myClass.newInstance();
-            ourAutoCommand = (Command) myObject;
-        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException ex) {
-            logger.error("failed to load class; instantiating default stub for: {}", myName);
-            ourAutoCommand = (Command) new ShooterDoNothing();
-            SmartDashboard.putNumber(TelemetryNames.Shooter.status, PKStatus.degraded.tlmValue);
-        }
-
-        defaultAutoCommand = ourAutoCommand;
-        SmartDashboard.putString(TelemetryNames.Shooter.autoCommand, ourAutoCommand.getClass().getSimpleName());
-
-        String myTeleClassName = props.getString("teleCommandName");
-        if (myTeleClassName.isEmpty()) {
-            logger.info("no class specified; go with subsystem default (do nothing)");
-            myTeleClassName = new StringBuilder().append(myName).append("DoNothing").toString();
-        }
-        myPkgName = ShooterDoNothing.class.getPackage().getName();
-        classToLoad = new StringBuilder().append(myPkgName).append(".").append(myTeleClassName).toString();
-        logger.debug("class to load: {}", classToLoad);
-
-        logger.info("constructing {} for {} subsystem", myTeleClassName, myName);
-        Command ourTeleCommand;
-        try {
-            @SuppressWarnings("rawtypes")
-            Class myClass = Class.forName(classToLoad);
-            @SuppressWarnings("deprecation")
-            Object myObject = myClass.newInstance();
-            ourTeleCommand = (Command) myObject;
-        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException ex) {
-            logger.error("failed to load class; instantiating default stub for: {}", myName);
-            ourTeleCommand = (Command) new ShooterDoNothing();
-            SmartDashboard.putNumber(TelemetryNames.Shooter.status, PKStatus.degraded.tlmValue);
-        }
-
-        defaultTeleCommand = ourTeleCommand;
-        SmartDashboard.putString(TelemetryNames.Shooter.teleCommand, ourTeleCommand.getClass().getSimpleName());
-    }
-
-    @Override
-    public void setDefaultAutoCommand() {
-        setDefaultCommand(defaultAutoCommand);
-    }
-
-    @Override
-    public void setDefaultTeleCommand() {
-        setDefaultCommand(defaultTeleCommand);
+        loadDefaultCommands(ShooterDoNothing.class);
     }
 
     protected void loadPreferences() {

--- a/src/main/java/frc/robot/subsystems/shooter/BaseShooterSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/shooter/BaseShooterSubsystem.java
@@ -60,7 +60,7 @@ abstract class BaseShooterSubsystem extends SubsystemBase implements IShooterSub
     private static Command defaultTeleCommand;
 
     @Override
-    public void loadDefaultCommand() {
+    public void loadDefaultCommands() {
         PKProperties props = PropertiesManager.getInstance().getProperties(myName);
         String myAutoClassName = props.getString("autoCommandName");
         if (myAutoClassName.isEmpty()) {
@@ -116,12 +116,12 @@ abstract class BaseShooterSubsystem extends SubsystemBase implements IShooterSub
     }
 
     @Override
-    public void loadDefaultAutoCommand() {
+    public void setDefaultAutoCommand() {
         setDefaultCommand(defaultAutoCommand);
     }
 
     @Override
-    public void loadDefaultTeleCommand() {
+    public void setDefaultTeleCommand() {
         setDefaultCommand(defaultTeleCommand);
     }
 

--- a/src/main/java/frc/robot/subsystems/turret/BaseTurretSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/turret/BaseTurretSubsystem.java
@@ -51,6 +51,8 @@ abstract class BaseTurretSubsystem extends BaseSubsystem implements ITurretSubsy
     @Override
     public void loadDefaultCommands() {
         loadDefaultCommands(TurretDoNothing.class);
+        SmartDashboard.putString(TelemetryNames.Turret.autoCommand, defaultAutoCommand.getClass().getSimpleName());
+        SmartDashboard.putString(TelemetryNames.Turret.teleCommand, defaultTeleCommand.getClass().getSimpleName());
     }
 
     protected void loadPreferences() {

--- a/src/main/java/frc/robot/subsystems/turret/BaseTurretSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/turret/BaseTurretSubsystem.java
@@ -57,7 +57,7 @@ abstract class BaseTurretSubsystem extends SubsystemBase implements ITurretSubsy
     private static Command defaultTeleCommand;
 
     @Override
-    public void loadDefaultCommand() {
+    public void loadDefaultCommands() {
         PKProperties props = PropertiesManager.getInstance().getProperties(myName);
         String myAutoClassName = props.getString("autoCommandName");
         if (myAutoClassName.isEmpty()) {
@@ -113,12 +113,12 @@ abstract class BaseTurretSubsystem extends SubsystemBase implements ITurretSubsy
     }
 
     @Override
-    public void loadDefaultAutoCommand() {
+    public void setDefaultAutoCommand() {
         setDefaultCommand(defaultAutoCommand);
     }
 
     @Override
-    public void loadDefaultTeleCommand() {
+    public void setDefaultTeleCommand() {
         setDefaultCommand(defaultTeleCommand);
     }
 

--- a/src/main/java/frc/robot/subsystems/turret/BaseTurretSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/turret/BaseTurretSubsystem.java
@@ -8,31 +8,26 @@
 
 package frc.robot.subsystems.turret;
 
+
 import edu.wpi.first.wpilibj.Preferences;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
-import edu.wpi.first.wpilibj2.command.Command;
-import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 import frc.robot.commands.turret.TurretDoNothing;
-import frc.robot.properties.PKProperties;
-import frc.robot.properties.PropertiesManager;
+import frc.robot.subsystems.BaseSubsystem;
 import frc.robot.subsystems.SubsystemNames;
 import frc.robot.telemetry.TelemetryNames;
-import frc.robot.utils.PKStatus;
 
 import riolog.PKLogger;
 import riolog.RioLogger;
 
+
 /**
  * Add your docs here.
  */
-abstract class BaseTurretSubsystem extends SubsystemBase implements ITurretSubsystem {
+abstract class BaseTurretSubsystem extends BaseSubsystem implements ITurretSubsystem {
 
     /** Our classes' logger **/
     private static final PKLogger logger = RioLogger.getLogger(BaseTurretSubsystem.class.getName());
-
-    /** Our subsystem's name **/
-    protected static final String myName = SubsystemNames.turretName;
 
     /** Default preferences for subystem **/
     private final double default_pid_P = 0.5;
@@ -47,79 +42,15 @@ abstract class BaseTurretSubsystem extends SubsystemBase implements ITurretSubsy
     protected double pid_F = 0;
 
     BaseTurretSubsystem() {
+        super(SubsystemNames.turretName);
         logger.info("constructing");
 
         logger.info("constructed");
     }
 
-    /** Objects to hold loaded default commands **/
-    private static Command defaultAutoCommand;
-    private static Command defaultTeleCommand;
-
     @Override
     public void loadDefaultCommands() {
-        PKProperties props = PropertiesManager.getInstance().getProperties(myName);
-        String myAutoClassName = props.getString("autoCommandName");
-        if (myAutoClassName.isEmpty()) {
-            logger.info("no class specified; go with subsystem default (do nothing)");
-            myAutoClassName = new StringBuilder().append(myName).append("DoNothing").toString();
-        }
-        String myPkgName = TurretDoNothing.class.getPackage().getName();
-        String classToLoad = new StringBuilder().append(myPkgName).append(".").append(myAutoClassName).toString();
-        logger.debug("class to load: {}", classToLoad);
-
-        logger.info("constructing {} for {} subsystem", myAutoClassName, myName);
-        Command ourAutoCommand;
-        try {
-            @SuppressWarnings("rawtypes")
-            Class myClass = Class.forName(classToLoad);
-            @SuppressWarnings("deprecation")
-            Object myObject = myClass.newInstance();
-            ourAutoCommand = (Command) myObject;
-        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException ex) {
-            logger.error("failed to load class; instantiating default stub for: {}", myName);
-            ourAutoCommand = (Command) new TurretDoNothing();
-            SmartDashboard.putNumber(TelemetryNames.Turret.status, PKStatus.degraded.tlmValue);
-        }
-
-        defaultAutoCommand = ourAutoCommand;
-        SmartDashboard.putString(TelemetryNames.Turret.autoCommand, ourAutoCommand.getClass().getSimpleName());
-
-        String myTeleClassName = props.getString("teleCommandName");
-        if (myTeleClassName.isEmpty()) {
-            logger.info("no class specified; go with subsystem default (do nothing)");
-            myTeleClassName = new StringBuilder().append(myName).append("DoNothing").toString();
-        }
-        myPkgName = TurretDoNothing.class.getPackage().getName();
-        classToLoad = new StringBuilder().append(myPkgName).append(".").append(myTeleClassName).toString();
-        logger.debug("class to load: {}", classToLoad);
-
-        logger.info("constructing {} for {} subsystem", myTeleClassName, myName);
-        Command ourTeleCommand;
-        try {
-            @SuppressWarnings("rawtypes")
-            Class myClass = Class.forName(classToLoad);
-            @SuppressWarnings("deprecation")
-            Object myObject = myClass.newInstance();
-            ourTeleCommand = (Command) myObject;
-        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException ex) {
-            logger.error("failed to load class; instantiating default stub for: {}", myName);
-            ourTeleCommand = (Command) new TurretDoNothing();
-            SmartDashboard.putNumber(TelemetryNames.Turret.status, PKStatus.degraded.tlmValue);
-        }
-
-        defaultTeleCommand = ourTeleCommand;
-        SmartDashboard.putString(TelemetryNames.Turret.teleCommand, ourTeleCommand.getClass().getSimpleName());
-    }
-
-    @Override
-    public void setDefaultAutoCommand() {
-        setDefaultCommand(defaultAutoCommand);
-    }
-
-    @Override
-    public void setDefaultTeleCommand() {
-        setDefaultCommand(defaultTeleCommand);
+        loadDefaultCommands(TurretDoNothing.class);
     }
 
     protected void loadPreferences() {


### PR DESCRIPTION
Implement the command loading in a base class to remove duplication of code and chances of copy and paste error.

Resolves #40, #56