### PR TITLE
Scrub Commands for Super Class Methods

### DIFF
--- a/src/main/java/frc/robot/commands/DoNothingButton.java
+++ b/src/main/java/frc/robot/commands/DoNothingButton.java
@@ -26,10 +26,9 @@ public class DoNothingButton extends PKCommandBase {
     private final String button;
 
     public DoNothingButton(String button) {
-        logger.info("constructing {}", getName());
+        logger.info("constructing {} for button {}", getName(), button);
 
         this.button = button;
-        logger.info("for button {}", button);
     }
 
 }

--- a/src/main/java/frc/robot/commands/FirePoseVision.java
+++ b/src/main/java/frc/robot/commands/FirePoseVision.java
@@ -8,6 +8,7 @@
 
 package frc.robot.commands;
 
+
 import frc.robot.sensors.vision.IVisionSensor;
 import frc.robot.sensors.vision.VisionFactory;
 import frc.robot.subsystems.elevator.ElevatorFactory;
@@ -19,6 +20,7 @@ import frc.robot.subsystems.shooter.ShooterFactory;
 
 import riolog.PKLogger;
 import riolog.RioLogger;
+
 
 public class FirePoseVision extends PKCommandBase {
 
@@ -71,11 +73,9 @@ public class FirePoseVision extends PKCommandBase {
     public void end(boolean interrupted) {
         super.end(interrupted);
 
+        // shooter goes to default (idle) when command ends
         incrementer.stop();
         elevator.stop();
-
-        // Don't stop shooter (default is idle command)
-        // shooter.stop();
     }
 
 }

--- a/src/main/java/frc/robot/commands/PKCommandBase.java
+++ b/src/main/java/frc/robot/commands/PKCommandBase.java
@@ -49,17 +49,16 @@ public abstract class PKCommandBase extends CommandBase {
     public static PKCommandBase[] getActiveCommands() {
         return activeCommandsList;
     }
-    
-    // Flag for whether the first execution has happened
-    private boolean executedOnce;
 
     protected PKCommandBase() {
         logger.info("constructing for {}", getName());
 
         logger.info("constructed");
     }
+    
+    // Flag for whether the first execution has happened
+    private boolean executedOnce;
 
-    // Called once just before this Command runs the first time
     @Override
     public void initialize() {
         logger.debug("initializing {}", getName());
@@ -67,23 +66,17 @@ public abstract class PKCommandBase extends CommandBase {
         executedOnce = false;
     }
 
-    // Called repeatedly while the Command is scheduled
     @Override
     public void execute() {
-        logExecuteStart(logger);
-    }
-
-    protected void logExecuteStart(PKLogger logger) {
         if (!executedOnce) {
-            executedOnce = true;
-            logger.trace("first execution of {}", getName());
+            logger.debug("first execution of {}", getName());
 
+            executedOnce = true;
+    
             add(this);
         }
     }
 
-    // Called once when either the Command finishes normally, or when it
-    // is interrupted/canceled.
     @Override
     public void end(boolean interrupted) {
         logger.debug("ending {} interrupted={}", getName(), interrupted);

--- a/src/main/java/frc/robot/commands/climber/ClimberClimb.java
+++ b/src/main/java/frc/robot/commands/climber/ClimberClimb.java
@@ -24,7 +24,6 @@ public class ClimberClimb extends ClimberCommandBase {
         logger.info("constructed");
     }
 
-        // Called every time the scheduler runs while the command is scheduled.
     @Override
     public void execute() {
         super.execute();
@@ -32,8 +31,6 @@ public class ClimberClimb extends ClimberCommandBase {
         climber.climb();
     }
 
-    // Called once when either the Command finishes normally, or when it
-    // is interrupted/canceled.
     @Override
     public void end(boolean interrupted) {
         super.end(interrupted);

--- a/src/main/java/frc/robot/commands/climber/ClimberClimbTimed.java
+++ b/src/main/java/frc/robot/commands/climber/ClimberClimbTimed.java
@@ -44,7 +44,6 @@ public class ClimberClimbTimed extends ClimberCommandBase {
         executeCount = secondsToClicks(timeInSeconds);
     }
 
-    // Called every time the scheduler runs while the command is scheduled.
     @Override
     public void execute() {
         super.execute();
@@ -59,13 +58,11 @@ public class ClimberClimbTimed extends ClimberCommandBase {
         return (executeCount > 0 ? false : true);
     }
 
-    // Called once when either the Command finishes normally, or when it
-    // is interrupted/canceled.
     @Override
     public void end(boolean interrupted) {
-        climber.stop();
-
         super.end(interrupted);
+
+        climber.stop();
     }
 
 }

--- a/src/main/java/frc/robot/commands/climber/ClimberCommandBase.java
+++ b/src/main/java/frc/robot/commands/climber/ClimberCommandBase.java
@@ -26,13 +26,12 @@ abstract class ClimberCommandBase extends PKCommandBase {
     private static final PKLogger logger = RioLogger.getLogger(ClimberCommandBase.class.getName());
 
     // Handle to our subsystem
-    protected IClimberSubsystem climber;
+    protected final IClimberSubsystem climber;
 
     public ClimberCommandBase() {
         logger.info("constructing {}", getName());
 
         climber = ClimberFactory.getInstance();
-
         addRequirements(climber);
 
         logger.info("constructed");

--- a/src/main/java/frc/robot/commands/climber/ClimberRetract.java
+++ b/src/main/java/frc/robot/commands/climber/ClimberRetract.java
@@ -24,7 +24,6 @@ public class ClimberRetract extends ClimberCommandBase {
         logger.info("constructed");
     }
 
-    // Called every time the scheduler runs while the command is scheduled.
     @Override
     public void execute() {
         super.execute();
@@ -32,8 +31,6 @@ public class ClimberRetract extends ClimberCommandBase {
         climber.retract();
     }
 
-    // Called once when either the Command finishes normally, or when it
-    // is interrupted/canceled.
     @Override
     public void end(boolean interrupted) {
         super.end(interrupted);

--- a/src/main/java/frc/robot/commands/climber/ClimberRunToTarget.java
+++ b/src/main/java/frc/robot/commands/climber/ClimberRunToTarget.java
@@ -10,7 +10,9 @@ package frc.robot.commands.climber;
 
 
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+
 import frc.robot.telemetry.TelemetryNames;
+
 import riolog.PKLogger;
 import riolog.RioLogger;
 
@@ -40,7 +42,6 @@ public class ClimberRunToTarget extends ClimberCommandBase {
         SmartDashboard.putBoolean(TelemetryNames.Climber.atTarget, false);
     }
 
-    // Called every time the scheduler runs while the command is scheduled.
     @Override
     public void execute() {
         super.execute();
@@ -53,14 +54,13 @@ public class ClimberRunToTarget extends ClimberCommandBase {
         return climber.getPosition() >= target;
     }
 
-    // Called once when either the Command finishes normally, or when it
-    // is interrupted/canceled.
     @Override
     public void end(boolean interrupted) {
-        SmartDashboard.putBoolean(TelemetryNames.Climber.atTarget, true);
+        super.end(interrupted);
+
         climber.stop();
 
-        super.end(interrupted);
+        SmartDashboard.putBoolean(TelemetryNames.Climber.atTarget, true);
     }
 
 }

--- a/src/main/java/frc/robot/commands/climber/ClimberSimpleManual.java
+++ b/src/main/java/frc/robot/commands/climber/ClimberSimpleManual.java
@@ -23,7 +23,6 @@ public class ClimberSimpleManual extends ClimberOICommandBase {
         logger.info("constructed");
     }
     
-    // Called repeatedly when this Command is scheduled to run
     @Override
     public void execute() {
         super.execute();
@@ -41,8 +40,6 @@ public class ClimberSimpleManual extends ClimberOICommandBase {
         climber.stop();
     }
 
-    // Called once when either the Command finishes normally, or when it
-    // is interrupted/canceled.
     @Override
     public void end(boolean interrupted) {
         super.end(interrupted);

--- a/src/main/java/frc/robot/commands/drive/DriveBackwardDistance.java
+++ b/src/main/java/frc/robot/commands/drive/DriveBackwardDistance.java
@@ -8,12 +8,14 @@
 
 package frc.robot.commands.drive;
 
+
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
 import frc.robot.telemetry.TelemetryNames;
 
 import riolog.PKLogger;
 import riolog.RioLogger;
+
 
 /**
  * Add your docs here.
@@ -64,10 +66,9 @@ public class DriveBackwardDistance extends DriveCommandBase {
 
     @Override
     public void end(boolean interrupted) {
-        // Stop the drive
-        drive.stop();
-
         super.end(interrupted);
+
+        drive.stop();
     }
 
 }

--- a/src/main/java/frc/robot/commands/drive/DriveBackwardTimed.java
+++ b/src/main/java/frc/robot/commands/drive/DriveBackwardTimed.java
@@ -65,10 +65,9 @@ public class DriveBackwardTimed extends DriveCommandBase {
 
     @Override
     public void end(boolean interrupted) {
-        // Stop the drive
-        drive.stop();
-
         super.end(interrupted);
+
+        drive.stop();
     }
 
 }

--- a/src/main/java/frc/robot/commands/drive/DriveCommandBase.java
+++ b/src/main/java/frc/robot/commands/drive/DriveCommandBase.java
@@ -26,13 +26,12 @@ abstract class DriveCommandBase extends PKCommandBase {
     private static final PKLogger logger = RioLogger.getLogger(DriveCommandBase.class.getName());
 
     // Handle to our subsystem
-    protected IDriveSubsystem drive;
+    protected final IDriveSubsystem drive;
 
     public DriveCommandBase() {
         logger.info("constructing {}", getName());
 
         drive = DriveFactory.getInstance();
-
         addRequirements(drive);
 
         logger.info("constructed");

--- a/src/main/java/frc/robot/commands/drive/DriveForwardDistance.java
+++ b/src/main/java/frc/robot/commands/drive/DriveForwardDistance.java
@@ -16,6 +16,7 @@ import frc.robot.telemetry.TelemetryNames;
 import riolog.PKLogger;
 import riolog.RioLogger;
 
+
 /**
  * Add your docs here.
  */
@@ -65,10 +66,10 @@ public class DriveForwardDistance extends DriveCommandBase {
 
     @Override
     public void end(boolean interrupted) {
+        super.end(interrupted);
+
         // Stop the drive
         drive.stop();
-
-        super.end(interrupted);
     }
 
 }

--- a/src/main/java/frc/robot/commands/drive/DriveForwardTimed.java
+++ b/src/main/java/frc/robot/commands/drive/DriveForwardTimed.java
@@ -9,7 +9,6 @@
 package frc.robot.commands.drive;
 
 
-import frc.robot.commands.intake.IntakeDoNothing;
 import riolog.PKLogger;
 import riolog.RioLogger;
 
@@ -66,10 +65,9 @@ public class DriveForwardTimed extends DriveCommandBase {
 
     @Override
     public void end(boolean interrupted) {
-        // Stop the drive
-        drive.stop();
-
         super.end(interrupted);
+
+        drive.stop();
     }
 
 }

--- a/src/main/java/frc/robot/commands/elevator/ElevatorCommandBase.java
+++ b/src/main/java/frc/robot/commands/elevator/ElevatorCommandBase.java
@@ -32,7 +32,6 @@ abstract class ElevatorCommandBase extends PKCommandBase {
         logger.info("constructing {}", getName());
 
         elevator = ElevatorFactory.getInstance();
-
         addRequirements(elevator);
 
         logger.info("constructed");

--- a/src/main/java/frc/robot/commands/elevator/ElevatorCommandBase.java
+++ b/src/main/java/frc/robot/commands/elevator/ElevatorCommandBase.java
@@ -26,7 +26,7 @@ abstract class ElevatorCommandBase extends PKCommandBase {
     private static final PKLogger logger = RioLogger.getLogger(ElevatorCommandBase.class.getName());
 
     // Handle to our subsystem
-    protected IElevatorSubsystem elevator;
+    protected final IElevatorSubsystem elevator;
 
     public ElevatorCommandBase() {
         logger.info("constructing {}", getName());

--- a/src/main/java/frc/robot/commands/elevator/ElevatorManualControl.java
+++ b/src/main/java/frc/robot/commands/elevator/ElevatorManualControl.java
@@ -26,7 +26,6 @@ public class ElevatorManualControl extends ElevatorOICommandBase {
 
     private boolean wasEnabled = false;
 
-    // Called every time the scheduler runs while the command is scheduled.
     @Override
     public void execute() {
         super.execute();

--- a/src/main/java/frc/robot/commands/incrementer/IncrementerCommandBase.java
+++ b/src/main/java/frc/robot/commands/incrementer/IncrementerCommandBase.java
@@ -26,13 +26,12 @@ abstract class IncrementerCommandBase extends PKCommandBase {
     private static final PKLogger logger = RioLogger.getLogger(IncrementerCommandBase.class.getName());
 
     // Handle to our subsystem
-    protected IIncrementerSubsystem incrementer;
+    protected final IIncrementerSubsystem incrementer;
 
     public IncrementerCommandBase() {
         logger.info("constructing {}", getName());
 
         incrementer = IncrementerFactory.getInstance();
-
         addRequirements(incrementer);
 
         logger.info("constructed");

--- a/src/main/java/frc/robot/commands/intake/IntakeCommandBase.java
+++ b/src/main/java/frc/robot/commands/intake/IntakeCommandBase.java
@@ -26,13 +26,12 @@ abstract class IntakeCommandBase extends PKCommandBase {
     private static final PKLogger logger = RioLogger.getLogger(IntakeCommandBase.class.getName());
 
     // Handle to our subsystem
-    protected IIntakeSubsystem intake;
+    protected final IIntakeSubsystem intake;
 
     public IntakeCommandBase() {
         logger.info("constructing {}", getName());
 
         intake = IntakeFactory.getInstance();
-
         addRequirements(intake);
 
         logger.info("constructed");

--- a/src/main/java/frc/robot/commands/intake/IntakeIngest.java
+++ b/src/main/java/frc/robot/commands/intake/IntakeIngest.java
@@ -34,10 +34,10 @@ public class IntakeIngest extends IntakeCommandBase {
 
     @Override
     public void end(boolean interrupted) {
+        super.end(interrupted);
+
         intake.stop();
         intake.retract();
-
-        super.end(interrupted);
     }
 
 }

--- a/src/main/java/frc/robot/commands/intake/IntakeIngestTimed.java
+++ b/src/main/java/frc/robot/commands/intake/IntakeIngestTimed.java
@@ -61,10 +61,10 @@ public class IntakeIngestTimed extends IntakeCommandBase {
 
     @Override
     public void end(boolean interrupted) {
+        super.end(interrupted);
+
         intake.stop();
         intake.retract();
-
-        super.end(interrupted);
     }
 
 }

--- a/src/main/java/frc/robot/commands/intake/IntakeManualControl.java
+++ b/src/main/java/frc/robot/commands/intake/IntakeManualControl.java
@@ -8,8 +8,10 @@
 
 package frc.robot.commands.intake;
 
+
 import riolog.PKLogger;
 import riolog.RioLogger;
+
 
 public class IntakeManualControl extends IntakeOICommandBase {
 

--- a/src/main/java/frc/robot/commands/shooter/ShooterCommandBase.java
+++ b/src/main/java/frc/robot/commands/shooter/ShooterCommandBase.java
@@ -26,13 +26,12 @@ abstract class ShooterCommandBase extends PKCommandBase {
     private static final PKLogger logger = RioLogger.getLogger(ShooterCommandBase.class.getName());
 
     // Handle to our subsystem
-    protected IShooterSubsystem shooter;
+    protected final IShooterSubsystem shooter;
 
     public ShooterCommandBase() {
         logger.info("constructing {}", getName());
 
         shooter = ShooterFactory.getInstance();
-
         addRequirements(shooter);
 
         logger.info("constructed");

--- a/src/main/java/frc/robot/commands/shooter/ShooterIdle.java
+++ b/src/main/java/frc/robot/commands/shooter/ShooterIdle.java
@@ -7,10 +7,12 @@
 
 package frc.robot.commands.shooter;
 
+
 import org.slf4j.Logger;
 
 import frc.robot.Robot;
 import riolog.RioLogger;
+
 
 /**
  * Add your docs here.

--- a/src/main/java/frc/robot/commands/turret/TurretCommandBase.java
+++ b/src/main/java/frc/robot/commands/turret/TurretCommandBase.java
@@ -26,13 +26,12 @@ abstract class TurretCommandBase extends PKCommandBase {
     private static final PKLogger logger = RioLogger.getLogger(TurretCommandBase.class.getName());
 
     // Handle to our subsystem
-    protected ITurretSubsystem turret;
+    protected final ITurretSubsystem turret;
 
     public TurretCommandBase() {
         logger.info("constructing {}", getName());
 
         turret = TurretFactory.getInstance();
-
         addRequirements(turret);
 
         logger.info("constructed");

--- a/src/main/java/frc/robot/commands/turret/TurretManualControlJog.java
+++ b/src/main/java/frc/robot/commands/turret/TurretManualControlJog.java
@@ -8,8 +8,10 @@
 
 package frc.robot.commands.turret;
 
+
 import riolog.PKLogger;
 import riolog.RioLogger;
+
 
 public class TurretManualControlJog extends TurretOICommandBase {
 
@@ -28,13 +30,12 @@ public class TurretManualControlJog extends TurretOICommandBase {
     // FIXME: This is a hack; use commands right
     boolean started = true;
 
-    // Called every time the scheduler runs while the command is scheduled.
     @Override
     public void execute() {
         super.execute();
 
         double speed = oi.getTurretJog();
-         turret.setSpeed(20, speed);
+        turret.setSpeed(20, speed);
     }
 
 }

--- a/src/main/java/frc/robot/config/BuildVersionInfo.java
+++ b/src/main/java/frc/robot/config/BuildVersionInfo.java
@@ -19,6 +19,6 @@ package frc.robot.config;
  **/
 class BuildVersionInfo {
     public static final String programmer = "Stu Lewin";
-    public static final String commitSHA = "650a5ac";
-    public static final String timeStamp = "20220311-051229";
+    public static final String commitSHA = "94248ce";
+    public static final String timeStamp = "20220311-060147";
 }


### PR DESCRIPTION
Makes sure that all commands make the calls to super class methods where required. Also optimized by removing a method call on each execute() invocation.

Resolved #58.